### PR TITLE
feat: Add Az.ResourceGraph to PowerShell module installation step

### DIFF
--- a/.github/workflows/pestertests.yml
+++ b/.github/workflows/pestertests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install PowerShell Module Dependencies from PSGallery
         run: |
           Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted
-          Install-Module -Name 'Az.Accounts'
+          Install-Module -Name 'Az.ResourceGraph', 'Az.Accounts'
         shell: pwsh
         continue-on-error: true
 


### PR DESCRIPTION
# Overview/Summary

Add the Az.ResourceGraph module to the PowerShell module installation step in the pestertests.

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
