### PR TITLE
fix: Start-WARACollector cmdlet parameter attributes

### DIFF
--- a/docs/advisor/Build-WAFAdvisorObject.md
+++ b/docs/advisor/Build-WAFAdvisorObject.md
@@ -13,7 +13,7 @@ Builds a list of advisory objects from Azure Advisor query results.
 ## SYNTAX
 
 ```
-Build-WAFAdvisorObject [[-AdvQueryResult] <Object>] [<CommonParameters>]
+Build-WAFAdvisorObject [[-AdvQueryResult] <Object>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,6 +39,21 @@ Aliases:
 
 Required: False
 Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/advisor/Get-WAFAdvisorRecommendations.md
+++ b/docs/advisor/Get-WAFAdvisorRecommendations.md
@@ -13,8 +13,8 @@ Retrieves high availability recommendations from Azure Advisor.
 ## SYNTAX
 
 ```
-Get-WAFAdvisorRecommendations [[-Subid] <Array>] [-HighAvailability] [-Security] [-Cost] [-Performance]
- [-OperationalExcellence] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-WAFAdvisorRecommendations [[-SubscriptionIds] <Array>] [-HighAvailability] [-Security] [-Cost]
+ [-Performance] [-OperationalExcellence] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,8 +30,8 @@ $subId = "22222222-2222-2222-2222-222222222222"
 
 ## PARAMETERS
 
-### -Subid
-The subscription ID for which to retrieve recommendations.
+### -SubscriptionIds
+{{ Fill SubscriptionIds Description }}
 
 ```yaml
 Type: Array

--- a/docs/advisor/Repair-WAFSubscriptionId.md
+++ b/docs/advisor/Repair-WAFSubscriptionId.md
@@ -1,11 +1,11 @@
 ---
-external help file: utils-help.xml
-Module Name: utils
+external help file: advisor-help.xml
+Module Name: advisor
 online version:
 schema: 2.0.0
 ---
 
-# Test-WAFResourceGroupId
+# Repair-WAFSubscriptionId
 
 ## SYNOPSIS
 {{ Fill in the Synopsis }}
@@ -13,7 +13,8 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Repair-WAFSubscriptionId [[-SubscriptionIds] <String[]>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,8 +31,8 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -InputValue
-{{ Fill InputValue Description }}
+### -SubscriptionIds
+{{ Fill SubscriptionIds Description }}
 
 ```yaml
 Type: String[]

--- a/docs/advisor/Test-WAFResourceGroupId.md
+++ b/docs/advisor/Test-WAFResourceGroupId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>]
+Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/advisor/Test-WAFSubscriptionId.md
+++ b/docs/advisor/Test-WAFSubscriptionId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFSubscriptionId [[-InputValue] <String[]>]
+Test-WAFSubscriptionId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/advisor/Test-WAFTagPattern.md
+++ b/docs/advisor/Test-WAFTagPattern.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFTagPattern [[-InputValue] <String[]>]
+Test-WAFTagPattern [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/advisor/advisor.md
+++ b/docs/advisor/advisor.md
@@ -14,6 +14,33 @@ Contains functions related to the capturing and collecting of data from Azure sp
 ### [Build-WAFAdvisorObject](Build-WAFAdvisorObject.md)
 Builds a list of advisory objects from Azure Advisor query results.
 
+### [Connect-WAFAzure](Connect-WAFAzure.md)
+Connects to an Azure tenant.
+
+### [Get-AzureRestMethodUriPath](Get-AzureRestMethodUriPath.md)
+Retrieves the path of the Azure REST API URI.
+
 ### [Get-WAFAdvisorRecommendations](Get-WAFAdvisorRecommendations.md)
 Retrieves high availability recommendations from Azure Advisor.
+
+### [Import-WAFConfigFileData](Import-WAFConfigFileData.md)
+Imports configuration data from a file.
+
+### [Invoke-AzureRestApi](Invoke-AzureRestApi.md)
+Invokes an Azure REST API then returns the response.
+
+### [Invoke-WAFQuery](Invoke-WAFQuery.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFIsGuid](Test-WAFIsGuid.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFResourceGroupId](Test-WAFResourceGroupId.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFSubscriptionId](Test-WAFSubscriptionId.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFTagPattern](Test-WAFTagPattern.md)
+{{ Fill in the Synopsis }}
 

--- a/docs/collector/Repair-WAFSubscriptionId.md
+++ b/docs/collector/Repair-WAFSubscriptionId.md
@@ -1,11 +1,11 @@
 ---
-external help file: utils-help.xml
-Module Name: utils
+external help file: collector-help.xml
+Module Name: collector
 online version:
 schema: 2.0.0
 ---
 
-# Test-WAFResourceGroupId
+# Repair-WAFSubscriptionId
 
 ## SYNOPSIS
 {{ Fill in the Synopsis }}
@@ -13,7 +13,8 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Repair-WAFSubscriptionId [[-SubscriptionIds] <String[]>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,8 +31,8 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -InputValue
-{{ Fill InputValue Description }}
+### -SubscriptionIds
+{{ Fill SubscriptionIds Description }}
 
 ```yaml
 Type: String[]

--- a/docs/collector/Test-WAFResourceGroupId.md
+++ b/docs/collector/Test-WAFResourceGroupId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>]
+Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/collector/Test-WAFSubscriptionId.md
+++ b/docs/collector/Test-WAFSubscriptionId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFSubscriptionId [[-InputValue] <String[]>]
+Test-WAFSubscriptionId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/collector/Test-WAFTagPattern.md
+++ b/docs/collector/Test-WAFTagPattern.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFTagPattern [[-InputValue] <String[]>]
+Test-WAFTagPattern [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/collector/collector.md
+++ b/docs/collector/collector.md
@@ -11,6 +11,12 @@ Locale: en-US
 Contains functions related to the capturing and collecting of data from Azure using KQL
 
 ## collector Cmdlets
+### [Connect-WAFAzure](Connect-WAFAzure.md)
+Connects to an Azure tenant.
+
+### [Get-AzureRestMethodUriPath](Get-AzureRestMethodUriPath.md)
+Retrieves the path of the Azure REST API URI.
+
 ### [Get-WAFQueryByResourceType](Get-WAFQueryByResourceType.md)
 Filters objects by resource type.
 
@@ -23,6 +29,27 @@ Retrieves all resources with matching tags.
 ### [Get-WAFTaggedRGResources](Get-WAFTaggedRGResources.md)
 Retrieves all resources in resource groups with matching tags.
 
+### [Import-WAFConfigFileData](Import-WAFConfigFileData.md)
+Imports configuration data from a file.
+
+### [Invoke-AzureRestApi](Invoke-AzureRestApi.md)
+Invokes an Azure REST API then returns the response.
+
+### [Invoke-WAFQuery](Invoke-WAFQuery.md)
+{{ Fill in the Synopsis }}
+
 ### [Invoke-WAFQueryLoop](Invoke-WAFQueryLoop.md)
 Invokes a loop to run queries for each recommendation object.
+
+### [Test-WAFIsGuid](Test-WAFIsGuid.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFResourceGroupId](Test-WAFResourceGroupId.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFSubscriptionId](Test-WAFSubscriptionId.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFTagPattern](Test-WAFTagPattern.md)
+{{ Fill in the Synopsis }}
 

--- a/docs/outage/Repair-WAFSubscriptionId.md
+++ b/docs/outage/Repair-WAFSubscriptionId.md
@@ -1,11 +1,11 @@
 ---
-external help file: utils-help.xml
-Module Name: utils
+external help file: outage-help.xml
+Module Name: outage
 online version:
 schema: 2.0.0
 ---
 
-# Test-WAFResourceGroupId
+# Repair-WAFSubscriptionId
 
 ## SYNOPSIS
 {{ Fill in the Synopsis }}
@@ -13,7 +13,8 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Repair-WAFSubscriptionId [[-SubscriptionIds] <String[]>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,8 +31,8 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -InputValue
-{{ Fill InputValue Description }}
+### -SubscriptionIds
+{{ Fill SubscriptionIds Description }}
 
 ```yaml
 Type: String[]

--- a/docs/outage/Test-WAFResourceGroupId.md
+++ b/docs/outage/Test-WAFResourceGroupId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>]
+Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/outage/Test-WAFSubscriptionId.md
+++ b/docs/outage/Test-WAFSubscriptionId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFSubscriptionId [[-InputValue] <String[]>]
+Test-WAFSubscriptionId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/outage/Test-WAFTagPattern.md
+++ b/docs/outage/Test-WAFTagPattern.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFTagPattern [[-InputValue] <String[]>]
+Test-WAFTagPattern [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/outage/outage.md
+++ b/docs/outage/outage.md
@@ -11,15 +11,36 @@ Locale: en-US
 Contains functions related to the capturing and collecting of data pertaining to Azure outages.
 
 ## outage Cmdlets
+### [Connect-WAFAzure](Connect-WAFAzure.md)
+Connects to an Azure tenant.
+
 ### [Get-AzureRestMethodUriPath](Get-AzureRestMethodUriPath.md)
 Retrieves the path of the Azure REST API URI.
 
 ### [Get-WAFOutage](Get-WAFOutage.md)
 {{ Fill in the Synopsis }}
 
+### [Import-WAFConfigFileData](Import-WAFConfigFileData.md)
+Imports configuration data from a file.
+
 ### [Invoke-AzureRestApi](Invoke-AzureRestApi.md)
 Invokes an Azure REST API then returns the response.
 
+### [Invoke-WAFQuery](Invoke-WAFQuery.md)
+{{ Fill in the Synopsis }}
+
 ### [New-WAFOutageObject](New-WAFOutageObject.md)
 Creates an outage object.
+
+### [Test-WAFIsGuid](Test-WAFIsGuid.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFResourceGroupId](Test-WAFResourceGroupId.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFSubscriptionId](Test-WAFSubscriptionId.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFTagPattern](Test-WAFTagPattern.md)
+{{ Fill in the Synopsis }}
 

--- a/docs/retirement/Repair-WAFSubscriptionId.md
+++ b/docs/retirement/Repair-WAFSubscriptionId.md
@@ -1,11 +1,11 @@
 ---
-external help file: utils-help.xml
-Module Name: utils
+external help file: retirement-help.xml
+Module Name: retirement
 online version:
 schema: 2.0.0
 ---
 
-# Test-WAFResourceGroupId
+# Repair-WAFSubscriptionId
 
 ## SYNOPSIS
 {{ Fill in the Synopsis }}
@@ -13,7 +13,8 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Repair-WAFSubscriptionId [[-SubscriptionIds] <String[]>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,8 +31,8 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -InputValue
-{{ Fill InputValue Description }}
+### -SubscriptionIds
+{{ Fill SubscriptionIds Description }}
 
 ```yaml
 Type: String[]

--- a/docs/retirement/Test-WAFResourceGroupId.md
+++ b/docs/retirement/Test-WAFResourceGroupId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>]
+Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/retirement/Test-WAFSubscriptionId.md
+++ b/docs/retirement/Test-WAFSubscriptionId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFSubscriptionId [[-InputValue] <String[]>]
+Test-WAFSubscriptionId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/retirement/Test-WAFTagPattern.md
+++ b/docs/retirement/Test-WAFTagPattern.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFTagPattern [[-InputValue] <String[]>]
+Test-WAFTagPattern [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/retirement/retirement.md
+++ b/docs/retirement/retirement.md
@@ -11,15 +11,36 @@ Locale: en-US
 Contains functions related to the capturing and collecting of data pertaining to resource retirements.
 
 ## retirement Cmdlets
+### [Connect-WAFAzure](Connect-WAFAzure.md)
+Connects to an Azure tenant.
+
 ### [Get-AzureRestMethodUriPath](Get-AzureRestMethodUriPath.md)
 Retrieves the path of the Azure REST API URI.
 
 ### [Get-WAFResourceRetirement](Get-WAFResourceRetirement.md)
 Retrieves active retirement health advisory events based on the specified subscription ID.
 
+### [Import-WAFConfigFileData](Import-WAFConfigFileData.md)
+Imports configuration data from a file.
+
 ### [Invoke-AzureRestApi](Invoke-AzureRestApi.md)
 Invokes an Azure REST API then returns the response.
 
+### [Invoke-WAFQuery](Invoke-WAFQuery.md)
+{{ Fill in the Synopsis }}
+
 ### [New-WAFResourceRetirementObject](New-WAFResourceRetirementObject.md)
 Creates a retirement object.
+
+### [Test-WAFIsGuid](Test-WAFIsGuid.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFResourceGroupId](Test-WAFResourceGroupId.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFSubscriptionId](Test-WAFSubscriptionId.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFTagPattern](Test-WAFTagPattern.md)
+{{ Fill in the Synopsis }}
 

--- a/docs/servicehealth/Build-WAFServiceHealthObject.md
+++ b/docs/servicehealth/Build-WAFServiceHealthObject.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Build-WAFServiceHealthObject [[-AdvQueryResult] <Object>]
+Build-WAFServiceHealthObject [[-AdvQueryResult] <Object>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,9 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/servicehealth/Repair-WAFSubscriptionId.md
+++ b/docs/servicehealth/Repair-WAFSubscriptionId.md
@@ -1,11 +1,11 @@
 ---
-external help file: utils-help.xml
-Module Name: utils
+external help file: servicehealth-help.xml
+Module Name: servicehealth
 online version:
 schema: 2.0.0
 ---
 
-# Test-WAFResourceGroupId
+# Repair-WAFSubscriptionId
 
 ## SYNOPSIS
 {{ Fill in the Synopsis }}
@@ -13,7 +13,8 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Repair-WAFSubscriptionId [[-SubscriptionIds] <String[]>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,8 +31,8 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -InputValue
-{{ Fill InputValue Description }}
+### -SubscriptionIds
+{{ Fill SubscriptionIds Description }}
 
 ```yaml
 Type: String[]

--- a/docs/servicehealth/Test-WAFResourceGroupId.md
+++ b/docs/servicehealth/Test-WAFResourceGroupId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>]
+Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/servicehealth/Test-WAFSubscriptionId.md
+++ b/docs/servicehealth/Test-WAFSubscriptionId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFSubscriptionId [[-InputValue] <String[]>]
+Test-WAFSubscriptionId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/servicehealth/Test-WAFTagPattern.md
+++ b/docs/servicehealth/Test-WAFTagPattern.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFTagPattern [[-InputValue] <String[]>]
+Test-WAFTagPattern [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/servicehealth/servicehealth.md
+++ b/docs/servicehealth/servicehealth.md
@@ -11,6 +11,36 @@ Locale: en-US
 Contains functions related to the capturing and collecting of data pertaining to Azure Service Health.
 
 ## servicehealth Cmdlets
+### [Build-WAFServiceHealthObject](Build-WAFServiceHealthObject.md)
+{{ Fill in the Synopsis }}
+
+### [Connect-WAFAzure](Connect-WAFAzure.md)
+Connects to an Azure tenant.
+
+### [Get-AzureRestMethodUriPath](Get-AzureRestMethodUriPath.md)
+Retrieves the path of the Azure REST API URI.
+
 ### [Get-WAFServiceHealth](Get-WAFServiceHealth.md)
+{{ Fill in the Synopsis }}
+
+### [Import-WAFConfigFileData](Import-WAFConfigFileData.md)
+Imports configuration data from a file.
+
+### [Invoke-AzureRestApi](Invoke-AzureRestApi.md)
+Invokes an Azure REST API then returns the response.
+
+### [Invoke-WAFQuery](Invoke-WAFQuery.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFIsGuid](Test-WAFIsGuid.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFResourceGroupId](Test-WAFResourceGroupId.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFSubscriptionId](Test-WAFSubscriptionId.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFTagPattern](Test-WAFTagPattern.md)
 {{ Fill in the Synopsis }}
 

--- a/docs/support/Repair-WAFSubscriptionId.md
+++ b/docs/support/Repair-WAFSubscriptionId.md
@@ -1,11 +1,11 @@
 ---
-external help file: utils-help.xml
-Module Name: utils
+external help file: support-help.xml
+Module Name: support
 online version:
 schema: 2.0.0
 ---
 
-# Test-WAFResourceGroupId
+# Repair-WAFSubscriptionId
 
 ## SYNOPSIS
 {{ Fill in the Synopsis }}
@@ -13,7 +13,8 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Repair-WAFSubscriptionId [[-SubscriptionIds] <String[]>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,8 +31,8 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -InputValue
-{{ Fill InputValue Description }}
+### -SubscriptionIds
+{{ Fill SubscriptionIds Description }}
 
 ```yaml
 Type: String[]

--- a/docs/support/Test-WAFResourceGroupId.md
+++ b/docs/support/Test-WAFResourceGroupId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>]
+Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/support/Test-WAFSubscriptionId.md
+++ b/docs/support/Test-WAFSubscriptionId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFSubscriptionId [[-InputValue] <String[]>]
+Test-WAFSubscriptionId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/support/Test-WAFTagPattern.md
+++ b/docs/support/Test-WAFTagPattern.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFTagPattern [[-InputValue] <String[]>]
+Test-WAFTagPattern [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/support/support.md
+++ b/docs/support/support.md
@@ -11,9 +11,36 @@ Locale: en-US
 Contains functions related to the capturing and collecting of data pertaining to Azure support tickets.
 
 ## support Cmdlets
+### [Connect-WAFAzure](Connect-WAFAzure.md)
+Connects to an Azure tenant.
+
+### [Get-AzureRestMethodUriPath](Get-AzureRestMethodUriPath.md)
+Retrieves the path of the Azure REST API URI.
+
 ### [Get-WAFSupportTicket](Get-WAFSupportTicket.md)
 {{ Fill in the Synopsis }}
 
+### [Import-WAFConfigFileData](Import-WAFConfigFileData.md)
+Imports configuration data from a file.
+
+### [Invoke-AzureRestApi](Invoke-AzureRestApi.md)
+Invokes an Azure REST API then returns the response.
+
+### [Invoke-WAFQuery](Invoke-WAFQuery.md)
+{{ Fill in the Synopsis }}
+
 ### [New-WAFSupportTicketObject](New-WAFSupportTicketObject.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFIsGuid](Test-WAFIsGuid.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFResourceGroupId](Test-WAFResourceGroupId.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFSubscriptionId](Test-WAFSubscriptionId.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFTagPattern](Test-WAFTagPattern.md)
 {{ Fill in the Synopsis }}
 

--- a/docs/utils/Repair-WAFSubscriptionId.md
+++ b/docs/utils/Repair-WAFSubscriptionId.md
@@ -5,7 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# Test-WAFResourceGroupId
+# Repair-WAFSubscriptionId
 
 ## SYNOPSIS
 {{ Fill in the Synopsis }}
@@ -13,7 +13,8 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Repair-WAFSubscriptionId [[-SubscriptionIds] <String[]>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,8 +31,8 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -InputValue
-{{ Fill InputValue Description }}
+### -SubscriptionIds
+{{ Fill SubscriptionIds Description }}
 
 ```yaml
 Type: String[]

--- a/docs/utils/Test-WAFSubscriptionId.md
+++ b/docs/utils/Test-WAFSubscriptionId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFSubscriptionId [[-InputValue] <String[]>]
+Test-WAFSubscriptionId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/utils/Test-WAFTagPattern.md
+++ b/docs/utils/Test-WAFTagPattern.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFTagPattern [[-InputValue] <String[]>]
+Test-WAFTagPattern [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +44,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/utils/utils.md
+++ b/docs/utils/utils.md
@@ -14,6 +14,27 @@ Contains various helper functions (Sorting, parsing, or building) and functions 
 ### [Connect-WAFAzure](Connect-WAFAzure.md)
 Connects to an Azure tenant.
 
+### [Get-AzureRestMethodUriPath](Get-AzureRestMethodUriPath.md)
+Retrieves the path of the Azure REST API URI.
+
 ### [Import-WAFConfigFileData](Import-WAFConfigFileData.md)
 Imports configuration data from a file.
+
+### [Invoke-AzureRestApi](Invoke-AzureRestApi.md)
+Invokes an Azure REST API then returns the response.
+
+### [Invoke-WAFQuery](Invoke-WAFQuery.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFIsGuid](Test-WAFIsGuid.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFResourceGroupId](Test-WAFResourceGroupId.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFSubscriptionId](Test-WAFSubscriptionId.md)
+{{ Fill in the Synopsis }}
+
+### [Test-WAFTagPattern](Test-WAFTagPattern.md)
+{{ Fill in the Synopsis }}
 

--- a/src/modules/wara/wara.psm1
+++ b/src/modules/wara/wara.psm1
@@ -38,7 +38,7 @@ Function Start-WARACollector {
 
         [Parameter(ParameterSetName = 'ConfigFileSet', Mandatory = $true)]
         [ValidateScript({ Test-Path $_ -PathType Leaf })]
-        $ConfigFile,
+        [string]$ConfigFile,
 
         [Parameter(ParameterSetName = 'Default')]
         [ValidatePattern('^https:\/\/.+$')]

--- a/src/modules/wara/wara.psm1
+++ b/src/modules/wara/wara.psm1
@@ -33,8 +33,8 @@ Function Start-WARACollector {
         [String[]]$Tags,
 
         [Parameter(ParameterSetName = 'Default')]
-        [ValidateSet('AzureCloud', 'AzureUSGovernment')]
-        $AzureEnvironment = 'AzureCloud',
+        [ValidateSet('AzureCloud', 'AzureUSGovernment', 'AzureGermanCloud', 'AzureChinaCloud')]
+        [string]$AzureEnvironment = 'AzureCloud',
 
         [Parameter(ParameterSetName = 'ConfigFileSet', Mandatory = $true)]
         [ValidateScript({ Test-Path $_ -PathType Leaf })]

--- a/src/modules/wara/wara.psm1
+++ b/src/modules/wara/wara.psm1
@@ -49,7 +49,8 @@ Function Start-WARACollector {
         [switch]$UseImplicitRunbookSelectors,
 
         [Parameter(ParameterSetName = 'Default')]
-        $RunbookFile
+        [ValidateScript({ Test-Path $_ -PathType Leaf })]
+        [string]$RunbookFile
     )
 
     Write-Debug "Debugging mode is enabled"


### PR DESCRIPTION
# Overview/Summary

Add missing data type and validation attributes to the `Start-WARACollector` cmdlet parameters.

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
