### PR TITLE
fix: Comment-based help

### DIFF
--- a/src/modules/wara/outage/outage.psm1
+++ b/src/modules/wara/outage/outage.psm1
@@ -28,9 +28,6 @@ using module ../utils/utils.psd1
 .PARAMETER SubscriptionIds
     The subscription ID for the Azure subscription to retrieve outage events.
 
-.PARAMETER ProgressAction
-    This is a common parameter, but this cmdlet does not use this parameter.
-
 .OUTPUTS
     Returns a list of outage events, including the name and properties of each event.
 
@@ -137,9 +134,6 @@ function Get-WAFOutage {
 
 .PARAMETER Description
     The description of the outage event.
-
-.PARAMETER ProgressAction
-    This is a common parameter, but this cmdlet does not use this parameter.
 
 .OUTPUTS
     Returns an OutageObject as a PSCustomObject.


### PR DESCRIPTION
# Overview/Summary

Fix comment-based help.

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
