### PR TITLE
fix: Util module

### DIFF
--- a/docs/advisor/Test-WAFIsGuid.md
+++ b/docs/advisor/Test-WAFIsGuid.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFIsGuid [-StringGuid] <Object> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFIsGuid [-StringGuid] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -34,7 +34,7 @@ PS C:\> {{ Add example code here }}
 {{ Fill StringGuid Description }}
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/collector/Test-WAFIsGuid.md
+++ b/docs/collector/Test-WAFIsGuid.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFIsGuid [-StringGuid] <Object> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFIsGuid [-StringGuid] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -34,7 +34,7 @@ PS C:\> {{ Add example code here }}
 {{ Fill StringGuid Description }}
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/outage/Test-WAFIsGuid.md
+++ b/docs/outage/Test-WAFIsGuid.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFIsGuid [-StringGuid] <Object> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFIsGuid [-StringGuid] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -34,7 +34,7 @@ PS C:\> {{ Add example code here }}
 {{ Fill StringGuid Description }}
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/retirement/Test-WAFIsGuid.md
+++ b/docs/retirement/Test-WAFIsGuid.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFIsGuid [-StringGuid] <Object> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFIsGuid [-StringGuid] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -34,7 +34,7 @@ PS C:\> {{ Add example code here }}
 {{ Fill StringGuid Description }}
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/servicehealth/Test-WAFIsGuid.md
+++ b/docs/servicehealth/Test-WAFIsGuid.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFIsGuid [-StringGuid] <Object> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFIsGuid [-StringGuid] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -34,7 +34,7 @@ PS C:\> {{ Add example code here }}
 {{ Fill StringGuid Description }}
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/support/Test-WAFIsGuid.md
+++ b/docs/support/Test-WAFIsGuid.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFIsGuid [-StringGuid] <Object> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFIsGuid [-StringGuid] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -34,7 +34,7 @@ PS C:\> {{ Add example code here }}
 {{ Fill StringGuid Description }}
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/utils/Test-WAFIsGuid.md
+++ b/docs/utils/Test-WAFIsGuid.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFIsGuid [-StringGuid] <Object> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFIsGuid [-StringGuid] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -34,7 +34,7 @@ PS C:\> {{ Add example code here }}
 {{ Fill StringGuid Description }}
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases:
 

--- a/src/modules/wara/utils/utils.psm1
+++ b/src/modules/wara/utils/utils.psm1
@@ -417,7 +417,7 @@ function Test-WAFIsGuid {
   [CmdletBinding()]
   param (
     [Parameter(Mandatory = $true)]
-    $StringGuid
+    [string]$StringGuid
   )
   $ObjectGuid = [System.Guid]::Empty
   if (-not [System.Guid]::TryParse($StringGuid, [ref]$ObjectGuid)) {

--- a/src/modules/wara/utils/utils.psm1
+++ b/src/modules/wara/utils/utils.psm1
@@ -27,99 +27,99 @@ Function Invoke-WAFQuery {
 
 <#
 .SYNOPSIS
-    Invokes an Azure REST API then returns the response.
+  Invokes an Azure REST API then returns the response.
 
 .DESCRIPTION
-    The Invoke-AzureRestApi function invokes an Azure REST API with the specified parameters then return the response.
+  The Invoke-AzureRestApi function invokes an Azure REST API with the specified parameters then return the response.
 
 .PARAMETER Method
-    The HTTP method to invoke the Azure REST API. The accepted values are GET, POST, PUT, PATCH, and DELETE.
+  The HTTP method to invoke the Azure REST API. The accepted values are GET, POST, PUT, PATCH, and DELETE.
 
 .PARAMETER SubscriptionId
-    The subscription ID that constitutes the URI for invoke the Azure REST API.
+  The subscription ID that constitutes the URI for invoke the Azure REST API.
 
 .PARAMETER ResourceGroupName
-    The resource group name that constitutes the URI for invoke the Azure REST API.
+  The resource group name that constitutes the URI for invoke the Azure REST API.
 
 .PARAMETER ResourceProviderName
-    The resource provider name that constitutes the URI for invoke the Azure REST API. It's usually as the XXXX.XXXX format.
+  The resource provider name that constitutes the URI for invoke the Azure REST API. It's usually as the XXXX.XXXX format.
 
 .PARAMETER ResourceType
-    The resource type that constitutes the URI for invoke the Azure REST API.
+  The resource type that constitutes the URI for invoke the Azure REST API.
 
 .PARAMETER Name
-    The resource name that constitutes the URI for invoke the Azure REST API.
+  The resource name that constitutes the URI for invoke the Azure REST API.
 
 .PARAMETER ApiVersion
-    The Azure REST API version that constitutes the URI for invoke the Azure REST API. It's usually as the yyyy-mm-dd format.
+  The Azure REST API version that constitutes the URI for invoke the Azure REST API. It's usually as the yyyy-mm-dd format.
 
 .PARAMETER QueryString
-    The query string that constitutes the URI for invoke the Azure REST API.
+  The query string that constitutes the URI for invoke the Azure REST API.
 
 .PARAMETER RequestBody
-    The request body for invoke the Azure REST API.
+  The request body for invoke the Azure REST API.
 
 .OUTPUTS
-    Returns a REST API response as the PSHttpResponse.
+  Returns a REST API response as the PSHttpResponse.
 
 .EXAMPLE
-    PS> $response = Invoke-AzureRestApi -Method 'GET' -SubscriptionId '11111111-1111-1111-1111-111111111111' -ResourceProviderName 'Microsoft.ResourceHealth' -ResourceType 'events' -ApiVersion '2024-02-01' -QueryString 'queryStartTime=2024-10-02T00:00:00'
+  PS> $response = Invoke-AzureRestApi -Method 'GET' -SubscriptionId '11111111-1111-1111-1111-111111111111' -ResourceProviderName 'Microsoft.ResourceHealth' -ResourceType 'events' -ApiVersion '2024-02-01' -QueryString 'queryStartTime=2024-10-02T00:00:00'
 
 .NOTES
-    Author: Takeshi Katano
-    Date: 2024-10-23
+  Author: Takeshi Katano
+  Date: 2024-10-23
 
-    This function requires the Az.Accounts module to be installed and imported.
+  This function requires the Az.Accounts module to be installed and imported.
 #>
 function Invoke-AzureRestApi {
   [CmdletBinding()]
   [OutputType([Microsoft.Azure.Commands.Profile.Models.PSHttpResponse])]
   param (
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
-      [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
-      [ValidateSet('GET', 'POST', 'PUT', 'PATCH', 'DELETE')]
-      [string] $Method,
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
+    [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
+    [ValidateSet('GET', 'POST', 'PUT', 'PATCH', 'DELETE')]
+    [string] $Method,
 
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
-      [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
-      [ValidatePattern('^[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}$')]
-      [string] $SubscriptionId,
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
+    [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
+    [ValidatePattern('^[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}$')]
+    [string] $SubscriptionId,
 
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
-      [ValidateLength(1, 90)]
-      [string] $ResourceGroupName,
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
+    [ValidateLength(1, 90)]
+    [string] $ResourceGroupName,
 
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
-      [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
-      [string] $ResourceProviderName,
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
+    [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
+    [string] $ResourceProviderName,
 
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
-      [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
-      [string] $ResourceType,
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
+    [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
+    [string] $ResourceType,
 
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
-      [string] $Name,
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
+    [string] $Name,
 
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
-      [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
-      [ValidatePattern('^[0-9]{4}(-[0-9]{2}){2}$')]
-      [string] $ApiVersion,
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
+    [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
+    [ValidatePattern('^[0-9]{4}(-[0-9]{2}){2}$')]
+    [string] $ApiVersion,
 
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $false)]
-      [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $false)]
-      [string] $QueryString,
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $false)]
+    [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $false)]
+    [string] $QueryString,
 
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $false)]
-      [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $false)]
-      [string] $RequestBody
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $false)]
+    [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $false)]
+    [string] $RequestBody
   )
 
   # Built the Azure REST API URI path.
   $cmdletParams = @{
-      SubscriptionId       = $SubscriptionId
-      ResourceProviderName = $ResourceProviderName
-      ResourceType         = $ResourceType
-      ApiVersion           = $ApiVersion
+    SubscriptionId       = $SubscriptionId
+    ResourceProviderName = $ResourceProviderName
+    ResourceType         = $ResourceType
+    ApiVersion           = $ApiVersion
   }
   if ($PSBoundParameters.ContainsKey('ResourceGroupName')) { $cmdletParams.ResourceGroupName = $ResourceGroupName }
   if ($PSBoundParameters.ContainsKey('Name')) { $cmdletParams.Name = $Name}
@@ -128,8 +128,8 @@ function Invoke-AzureRestApi {
 
   # Invoke the Azure REST API using the URI path.
   $cmdletParams = @{
-      Method = $Method
-      Path   = $path
+    Method = $Method
+    Path   = $path
   }
   if ($PSBoundParameters.ContainsKey('RequestBody')) { $cmdletParams.Payload = $RequestBody }
   return Invoke-AzRestMethod @cmdletParams
@@ -179,45 +179,45 @@ function Get-AzureRestMethodUriPath {
   [CmdletBinding()]
   [OutputType([string])]
   param (
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
-      [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
-      [ValidatePattern('^[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}$')]
-      [string] $SubscriptionId,
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
+    [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
+    [ValidatePattern('^[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}$')]
+    [string] $SubscriptionId,
 
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
-      [ValidateLength(1, 90)]
-      [string] $ResourceGroupName,
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
+    [ValidateLength(1, 90)]
+    [string] $ResourceGroupName,
 
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
-      [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
-      [string] $ResourceProviderName,
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
+    [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
+    [string] $ResourceProviderName,
 
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
-      [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
-      [string] $ResourceType,
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
+    [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
+    [string] $ResourceType,
 
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
-      [string] $Name,
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
+    [string] $Name,
 
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
-      [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
-      [ValidatePattern('^[0-9]{4}(-[0-9]{2}){2}$')]
-      [string] $ApiVersion,
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
+    [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
+    [ValidatePattern('^[0-9]{4}(-[0-9]{2}){2}$')]
+    [string] $ApiVersion,
 
-      [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $false)]
-      [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $false)]
-      [string] $QueryString
+    [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $false)]
+    [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $false)]
+    [string] $QueryString
   )
 
   $additionalQueryString = if ($PSBoundParameters.ContainsKey('QueryString')) { '&' + $QueryString } else { '' }
   $path = if ($PSCmdlet.ParameterSetName -eq 'WithResourceGroup') {
-      '/subscriptions/{0}/resourcegroups/{1}/providers/{2}/{3}/{4}?api-version={5}{6}' -f $SubscriptionId, $ResourceGroupName, $ResourceProviderName, $ResourceType, $Name, $ApiVersion, $additionalQueryString
+    '/subscriptions/{0}/resourcegroups/{1}/providers/{2}/{3}/{4}?api-version={5}{6}' -f $SubscriptionId, $ResourceGroupName, $ResourceProviderName, $ResourceType, $Name, $ApiVersion, $additionalQueryString
   }
   elseif ($PSCmdlet.ParameterSetName -eq 'WithoutResourceGroup') {
-      '/subscriptions/{0}/providers/{1}/{2}?api-version={3}{4}' -f $SubscriptionId, $ResourceProviderName, $ResourceType, $ApiVersion, $additionalQueryString
+    '/subscriptions/{0}/providers/{1}/{2}?api-version={3}{4}' -f $SubscriptionId, $ResourceProviderName, $ResourceType, $ApiVersion, $additionalQueryString
   }
   else {
-      throw 'Invalid ParameterSetName'
+    throw 'Invalid ParameterSetName'
   }
   return $path
 }

--- a/src/modules/wara/utils/utils.psm1
+++ b/src/modules/wara/utils/utils.psm1
@@ -82,7 +82,7 @@ function Invoke-AzureRestApi {
 
     [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
     [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
-    [ValidatePattern('^[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}$')]
+    [ValidateScript({ Test-WAFIsGuid -StringGuid $_ })]
     [string] $SubscriptionId,
 
     [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
@@ -181,7 +181,7 @@ function Get-AzureRestMethodUriPath {
   param (
     [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]
     [Parameter(ParameterSetName = 'WithoutResourceGroup', Mandatory = $true)]
-    [ValidatePattern('^[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}$')]
+    [ValidateScript({ Test-WAFIsGuid -StringGuid $_ })]
     [string] $SubscriptionId,
 
     [Parameter(ParameterSetName = 'WithResourceGroup', Mandatory = $true)]

--- a/src/modules/wara/utils/utils.psm1
+++ b/src/modules/wara/utils/utils.psm1
@@ -217,7 +217,7 @@ function Get-AzureRestMethodUriPath {
     '/subscriptions/{0}/providers/{1}/{2}?api-version={3}{4}' -f $SubscriptionId, $ResourceProviderName, $ResourceType, $ApiVersion, $additionalQueryString
   }
   else {
-    throw 'Invalid ParameterSetName'
+    throw "The parameter set name [$($PSCmdlet.ParameterSetName)] is invalid."
   }
   return $path
 }

--- a/src/modules/wara/utils/utils.psm1
+++ b/src/modules/wara/utils/utils.psm1
@@ -25,7 +25,6 @@ Function Invoke-WAFQuery {
   return $allResources
 }
 
-
 <#
 .SYNOPSIS
     Invokes an Azure REST API then returns the response.
@@ -60,9 +59,6 @@ Function Invoke-WAFQuery {
 .PARAMETER RequestBody
     The request body for invoke the Azure REST API.
 
-.PARAMETER ProgressAction
-    This is a common parameter, but this cmdlet does not use this parameter.
-
 .OUTPUTS
     Returns a REST API response as the PSHttpResponse.
 
@@ -74,7 +70,6 @@ Function Invoke-WAFQuery {
     Date: 2024-10-23
 
     This function requires the Az.Accounts module to be installed and imported.
-    This function should be placed in a common module such as a utility/helper module because the capability of this function is common across modules.
 #>
 function Invoke-AzureRestApi {
   [CmdletBinding()]
@@ -170,9 +165,6 @@ function Invoke-AzureRestApi {
 .PARAMETER QueryString
   The query string that constitutes the path of Azure REST API URI.
 
-.PARAMETER ProgressAction
-  This is a common parameter, but this cmdlet does not use this parameter.
-
 .OUTPUTS
   Returns a URI path to call Azure REST API.
 
@@ -182,8 +174,6 @@ function Invoke-AzureRestApi {
 .NOTES
   Author: Takeshi Katano
   Date: 2024-10-23
-
-  This function should be placed in a common module such as a utility/helper module because the capability of this function is common across modules.
 #>
 function Get-AzureRestMethodUriPath {
   [CmdletBinding()]
@@ -231,7 +221,6 @@ function Get-AzureRestMethodUriPath {
   }
   return $path
 }
-
 
 <#
 .SYNOPSIS


### PR DESCRIPTION
# Overview/Summary

- Specify data type to a parameter of Test-WAFIsGuid.
- Fix comment-based help for Invoke-AzureRestApi and Get-AzureRestMethodUriPath.
- Use the util module's function to validate GUID for Invoke-AzureRestApi and Get-AzureRestMethodUriPath.
- Fix indentation for Invoke-AzureRestApi.

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
