### PR TITLE
fix: Connect to Azure tenant issue when the current tenant is different with specified

### DIFF
--- a/src/modules/wara/utils/utils.psm1
+++ b/src/modules/wara/utils/utils.psm1
@@ -351,7 +351,7 @@ function Connect-WAFAzure {
   )
 
   # Connect To Azure Tenant
-  if (-not (Get-AzContext)) {
+  if ((Get-AzContext).Tenant.Id -ne $TenantID) {
     Connect-AzAccount -Tenant $TenantID -WarningAction SilentlyContinue -Environment $AzureEnvironment
   }
 }


### PR DESCRIPTION
# Overview/Summary

Fix the connect to Azure tenant issue when the current tenant is different with specified by the TenantID parameter. Also, update tests for Connect-WAFAzure.

Repro steps:

1. The current context is for **Tenant A**.
2. Run Start-WARACollector with **Tenant B** as the TenantID parameter.
3. It doesn't run correctly.

![image](https://github.com/user-attachments/assets/78657bca-4352-4717-a32a-daeecb3fae31)

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
