### PR TITLE
Fix return value to always as array

### DIFF
--- a/src/modules/wara/utils/utils.psm1
+++ b/src/modules/wara/utils/utils.psm1
@@ -21,7 +21,7 @@ function Invoke-WAFQuery {
     $allResources += $result
 
     # Output all resources
-    return $allResources
+    return ,$allResources
 }
 
 <#


### PR DESCRIPTION
# Overview/Summary

Fix the return value to always as an array.

Invoke-WAFQuery returns $null if the return value is an empty array (= there are no query result). For fix this, added a comma (array operator). Then the return value is always as an array.

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
