### PR TITLE
fix: Fix return value of Invoke-WAFQuery

### DIFF
--- a/src/modules/wara/collector/collector.psm1
+++ b/src/modules/wara/collector/collector.psm1
@@ -170,7 +170,7 @@ function Invoke-WAFQueryLoop {
     $return = $QueryObject.Where({ $_.automationavailable -eq $true -and [string]::IsNullOrEmpty($_.recommendationTypeId) }) | ForEach-Object {
         Write-Progress -Activity 'Running Queries' -Status "Running Query for $($_.recommendationResourceType) - $($_.aprlGuid)" -PercentComplete (($QueryObject.IndexOf($_) / $QueryObject.Count) * 100) -Id 1
         try {
-            Invoke-WAFQuery -Query $_.query -SubscriptionIds $subscriptionIds -ErrorAction Stop
+            (Invoke-WAFQuery -Query $_.query -SubscriptionIds $subscriptionIds -ErrorAction Stop)
         }
         catch {
             Write-Host "Error running query for - $($_.recommendationResourceType) - $($_.aprlGuid)"

--- a/src/modules/wara/utils/utils.psm1
+++ b/src/modules/wara/utils/utils.psm1
@@ -21,7 +21,7 @@ function Invoke-WAFQuery {
     $allResources += $result
 
     # Output all resources
-    return $allResources
+    return ,$allResources
 }
 
 <#


### PR DESCRIPTION
# Overview/Summary

Fix the return value of Invoke-WAFQuery function.

Invoke-WAFQuery returns $null if there are no query result. For fix this, added a comma (use array operator). Then the return value is always as an array. The function returns an empty array if there are no query result.

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
