### PR TITLE
fix: Add explicit data type to parameters

### DIFF
--- a/docs/advisor/Build-WAFAdvisorObject.md
+++ b/docs/advisor/Build-WAFAdvisorObject.md
@@ -13,7 +13,7 @@ Builds a list of advisory objects from Azure Advisor query results.
 ## SYNTAX
 
 ```
-Build-WAFAdvisorObject [[-AdvQueryResult] <Object>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Build-WAFAdvisorObject [-AdvQueryResult] <PSObject[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -33,11 +33,11 @@ $advQueryResult = Get-WAFAdvisorRecommendations -Subid "12345"
 An array of query results from Azure Advisor.
 
 ```yaml
-Type: Object
+Type: PSObject[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 1
 Default value: None
 Accept pipeline input: False

--- a/docs/advisor/Get-WAFAdvisorRecommendation.md
+++ b/docs/advisor/Get-WAFAdvisorRecommendation.md
@@ -13,8 +13,8 @@ Retrieves high availability recommendations from Azure Advisor.
 ## SYNTAX
 
 ```
-Get-WAFAdvisorRecommendation [[-SubscriptionIds] <Array>] [-HighAvailability] [-Security] [-Cost]
- [-Performance] [-OperationalExcellence] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-WAFAdvisorRecommendation [-SubscriptionIds] <Array> [-HighAvailability] [-Security] [-Cost] [-Performance]
+ [-OperationalExcellence] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: Array
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 1
 Default value: None
 Accept pipeline input: False

--- a/docs/advisor/Test-WAFResourceGroupId.md
+++ b/docs/advisor/Test-WAFResourceGroupId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFResourceGroupId [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/advisor/Test-WAFSubscriptionId.md
+++ b/docs/advisor/Test-WAFSubscriptionId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFSubscriptionId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFSubscriptionId [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/advisor/Test-WAFTagPattern.md
+++ b/docs/advisor/Test-WAFTagPattern.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFTagPattern [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFTagPattern [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/collector/Get-WAFQueryByResourceType.md
+++ b/docs/collector/Get-WAFQueryByResourceType.md
@@ -13,7 +13,7 @@ Filters objects by resource type.
 ## SYNTAX
 
 ```
-Get-WAFQueryByResourceType [-ObjectList] <Array> [-FilterList] <Array> [-KeyColumn] <String>
+Get-WAFQueryByResourceType [-ObjectList] <PSObject[]> [-FilterList] <String[]> [-KeyColumn] <String>
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
@@ -33,7 +33,7 @@ $filteredObjects = Get-WAFQueryByResourceType -ObjectList $objects -FilterList $
 An array of objects to filter.
 
 ```yaml
-Type: Array
+Type: PSObject[]
 Parameter Sets: (All)
 Aliases:
 
@@ -48,7 +48,7 @@ Accept wildcard characters: False
 An array of resource types to filter by.
 
 ```yaml
-Type: Array
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/collector/Get-WAFResourceType.md
+++ b/docs/collector/Get-WAFResourceType.md
@@ -13,7 +13,7 @@ Retrieves all resource types in the specified subscriptions.
 ## SYNTAX
 
 ```
-Get-WAFResourceType [[-SubscriptionIds] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-WAFResourceType [-SubscriptionIds] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -36,7 +36,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 1
 Default value: None
 Accept pipeline input: False

--- a/docs/collector/Get-WAFTaggedResource.md
+++ b/docs/collector/Get-WAFTaggedResource.md
@@ -13,8 +13,8 @@ Retrieves all resources with matching tags.
 ## SYNTAX
 
 ```
-Get-WAFTaggedResource [[-tagArray] <Array>] [[-subscriptionIds] <String[]>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-WAFTaggedResource [-TagArray] <String[]> [-SubscriptionIds] <String[]> [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -29,23 +29,23 @@ $taggedResources = Get-WAFTaggedResources -tagArray @('env==prod', 'app==myapp')
 
 ## PARAMETERS
 
-### -tagArray
+### -TagArray
 An array of tags to filter resources by.
 Each tag should be in the format 'key==value'.
 
 ```yaml
-Type: Array
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -subscriptionIds
+### -SubscriptionIds
 An array of subscription IDs to scope the query.
 
 ```yaml
@@ -53,7 +53,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/collector/Get-WAFTaggedResourceGroup.md
+++ b/docs/collector/Get-WAFTaggedResourceGroup.md
@@ -13,7 +13,7 @@ Retrieves all resources in resource groups with matching tags.
 ## SYNTAX
 
 ```
-Get-WAFTaggedResourceGroup [[-tagArray] <Array>] [[-subscriptionIds] <String[]>]
+Get-WAFTaggedResourceGroup [-TagArray] <String[]> [-SubscriptionIds] <String[]>
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
@@ -29,22 +29,22 @@ $taggedRGResources = Get-WAFTaggedRGResources -tagKeys @('env') -tagValues @('pr
 
 ## PARAMETERS
 
-### -tagArray
+### -TagArray
 {{ Fill tagArray Description }}
 
 ```yaml
-Type: Array
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -subscriptionIds
+### -SubscriptionIds
 An array of subscription IDs to scope the query.
 
 ```yaml
@@ -52,7 +52,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/collector/Invoke-WAFQueryLoop.md
+++ b/docs/collector/Invoke-WAFQueryLoop.md
@@ -13,7 +13,7 @@ Invokes a loop to run queries for each recommendation object.
 ## SYNTAX
 
 ```
-Invoke-WAFQueryLoop [[-RecommendationObject] <Object>] [[-subscriptionIds] <String[]>]
+Invoke-WAFQueryLoop [-RecommendationObject] <PSObject[]> [-SubscriptionIds] <String[]>
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
@@ -33,18 +33,18 @@ $resources = Invoke-WAFQueryLoop -RecommendationObject $recommendations -subscri
 An array of recommendation objects to query.
 
 ```yaml
-Type: Object
+Type: PSObject[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -subscriptionIds
+### -SubscriptionIds
 An array of subscription IDs to scope the query.
 
 ```yaml
@@ -52,7 +52,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 2
 Default value: None
 Accept pipeline input: False

--- a/docs/collector/Test-WAFResourceGroupId.md
+++ b/docs/collector/Test-WAFResourceGroupId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFResourceGroupId [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/collector/Test-WAFSubscriptionId.md
+++ b/docs/collector/Test-WAFSubscriptionId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFSubscriptionId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFSubscriptionId [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/collector/Test-WAFTagPattern.md
+++ b/docs/collector/Test-WAFTagPattern.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFTagPattern [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFTagPattern [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/outage/Test-WAFResourceGroupId.md
+++ b/docs/outage/Test-WAFResourceGroupId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFResourceGroupId [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/outage/Test-WAFSubscriptionId.md
+++ b/docs/outage/Test-WAFSubscriptionId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFSubscriptionId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFSubscriptionId [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/outage/Test-WAFTagPattern.md
+++ b/docs/outage/Test-WAFTagPattern.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFTagPattern [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFTagPattern [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/retirement/Test-WAFResourceGroupId.md
+++ b/docs/retirement/Test-WAFResourceGroupId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFResourceGroupId [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/retirement/Test-WAFSubscriptionId.md
+++ b/docs/retirement/Test-WAFSubscriptionId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFSubscriptionId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFSubscriptionId [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/retirement/Test-WAFTagPattern.md
+++ b/docs/retirement/Test-WAFTagPattern.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFTagPattern [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFTagPattern [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/scope/Get-WAFFilteredResourceList.md
+++ b/docs/scope/Get-WAFFilteredResourceList.md
@@ -13,8 +13,8 @@ Retrieves a filtered list of Azure resources based on subscription, resource gro
 ## SYNTAX
 
 ```
-Get-WAFFilteredResourceList [[-SubscriptionFilters] <Array>] [[-ResourceGroupFilters] <Array>]
- [[-ResourceFilters] <Array>] [[-UnfilteredResources] <Array>] [[-KeyColumn] <String>]
+Get-WAFFilteredResourceList [[-SubscriptionFilters] <String[]>] [[-ResourceGroupFilters] <String[]>]
+ [[-ResourceFilters] <String[]>] [-UnfilteredResources] <Array> [[-KeyColumn] <String>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
@@ -39,7 +39,7 @@ $filteredResources = Get-WAFFilteredResourceList -SubscriptionFilters $subscript
 An array of subscription identifiers to filter the resources.
 
 ```yaml
-Type: Array
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 
@@ -54,7 +54,7 @@ Accept wildcard characters: False
 An array of resource group identifiers to filter the resources.
 
 ```yaml
-Type: Array
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 
@@ -69,7 +69,7 @@ Accept wildcard characters: False
 An array of resource identifiers to filter the resources.
 
 ```yaml
-Type: Array
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 
@@ -88,7 +88,7 @@ Type: Array
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 4
 Default value: None
 Accept pipeline input: False

--- a/docs/servicehealth/Build-WAFServiceHealthObject.md
+++ b/docs/servicehealth/Build-WAFServiceHealthObject.md
@@ -13,7 +13,8 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Build-WAFServiceHealthObject [[-AdvQueryResult] <Object>] [<CommonParameters>]
+Build-WAFServiceHealthObject [-AdvQueryResult] <PSObject[]> [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -34,12 +35,27 @@ PS C:\> {{ Add example code here }}
 {{ Fill AdvQueryResult Description }}
 
 ```yaml
-Type: Object
+Type: PSObject[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/servicehealth/Get-WAFServiceHealth.md
+++ b/docs/servicehealth/Get-WAFServiceHealth.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Get-WAFServiceHealth [[-SubscriptionIds] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-WAFServiceHealth [-SubscriptionIds] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/servicehealth/Test-WAFResourceGroupId.md
+++ b/docs/servicehealth/Test-WAFResourceGroupId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFResourceGroupId [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/servicehealth/Test-WAFSubscriptionId.md
+++ b/docs/servicehealth/Test-WAFSubscriptionId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFSubscriptionId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFSubscriptionId [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/servicehealth/Test-WAFTagPattern.md
+++ b/docs/servicehealth/Test-WAFTagPattern.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFTagPattern [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFTagPattern [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/support/Test-WAFResourceGroupId.md
+++ b/docs/support/Test-WAFResourceGroupId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFResourceGroupId [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/support/Test-WAFSubscriptionId.md
+++ b/docs/support/Test-WAFSubscriptionId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFSubscriptionId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFSubscriptionId [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/support/Test-WAFTagPattern.md
+++ b/docs/support/Test-WAFTagPattern.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFTagPattern [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFTagPattern [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/utils/Test-WAFResourceGroupId.md
+++ b/docs/utils/Test-WAFResourceGroupId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFResourceGroupId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFResourceGroupId [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/utils/Test-WAFSubscriptionId.md
+++ b/docs/utils/Test-WAFSubscriptionId.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFSubscriptionId [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFSubscriptionId [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/docs/utils/Test-WAFTagPattern.md
+++ b/docs/utils/Test-WAFTagPattern.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-Test-WAFTagPattern [[-InputValue] <String[]>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Test-WAFTagPattern [-InputValue] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ Type: String[]
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 0
 Default value: None
 Accept pipeline input: False

--- a/src/modules/wara/advisor/advisor.psm1
+++ b/src/modules/wara/advisor/advisor.psm1
@@ -24,6 +24,8 @@ using module ../utils/utils.psd1
 function Get-WAFAdvisorRecommendation {
     [CmdletBinding()]
     param (
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
         [array] $SubscriptionIds,
 
         [switch] $HighAvailability,
@@ -89,7 +91,9 @@ function Get-WAFAdvisorRecommendation {
 function Build-WAFAdvisorObject {
     [CmdletBinding()]
     param (
-        $AdvQueryResult
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [PSCustomObject[]] $AdvQueryResult
     )
 
     $return = $AdvQueryResult.ForEach({ [advisorResourceObj]::new($_) })

--- a/src/modules/wara/collector/collector.psm1
+++ b/src/modules/wara/collector/collector.psm1
@@ -25,14 +25,17 @@ using module ../utils/utils.psd1
 function Get-WAFTaggedResource {
     [CmdletBinding()]
     param (
-        [array] $tagArray,
+        [Parameter(Mandatory = $true)]
+        [string[]] $TagArray,
 
-        [string[]] $subscriptionIds
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [string[]] $SubscriptionIds
     )
 
     $return = @()
 
-    foreach ($tag in $tagArray) {
+    foreach ($tag in $TagArray) {
         switch -Wildcard ($tag) {
             "*=~*" {
                 $tagKeys = $tag.Split("=~")[0].split("||") -join ("','")
@@ -54,12 +57,12 @@ function Get-WAFTaggedResource {
 | summarize by id
 | order by ['id']"
 
-        $result = Invoke-WAFQuery -Query $tagquery -SubscriptionIds $subscriptionIds
+        $result = Invoke-WAFQuery -Query $tagquery -SubscriptionIds $SubscriptionIds
 
         $return += $result
     }
 
-    $return = ($return | Group-Object id | Where-Object { $_.count -eq $tagArray.Count } | Select-Object Name).Name
+    $return = ($return | Group-Object id | Where-Object { $_.count -eq $TagArray.Count } | Select-Object Name).Name
 
     return $return
 }
@@ -92,14 +95,17 @@ function Get-WAFTaggedResource {
 function Get-WAFTaggedResourceGroup {
     [CmdletBinding()]
     param (
-        [array] $tagArray,
+        [Parameter(Mandatory = $true)]
+        [string[]] $TagArray,
 
-        [string[]] $subscriptionIds
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [string[]] $SubscriptionIds
     )
 
     $return = @()
 
-    foreach ($tag in $tagArray) {
+    foreach ($tag in $TagArray) {
         switch -Wildcard ($tag) {
             "*=~*" {
                 $tagKeys = $tag.Split("=~")[0].split("||") -join ("','")
@@ -123,12 +129,12 @@ function Get-WAFTaggedResourceGroup {
 | summarize by id
 | order by ['id']"
 
-        $result = Invoke-WAFQuery -Query $tagquery -SubscriptionIds $subscriptionIds
+        $result = Invoke-WAFQuery -Query $tagquery -SubscriptionIds $SubscriptionIds
     
         $return += $result
     }
 
-    $return = ($return | Group-Object id | Where-Object { $_.count -eq $tagArray.Count } | Select-Object Name).Name
+    $return = ($return | Group-Object id | Where-Object { $_.count -eq $TagArray.Count } | Select-Object Name).Name
 
     return $return
 }
@@ -158,19 +164,22 @@ function Get-WAFTaggedResourceGroup {
 function Invoke-WAFQueryLoop {
     [CmdletBinding()]
     param (
-        $RecommendationObject,
+        [Parameter(Mandatory = $true)]
+        [PSCustomObject[]] $RecommendationObject,
 
-        [string[]] $subscriptionIds
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [string[]] $SubscriptionIds
     )
 
-    $Types = Get-WAFResourceType -SubscriptionIds $subscriptionIds
+    $Types = Get-WAFResourceType -SubscriptionIds $SubscriptionIds
 
     $QueryObject = Get-WAFQueryByResourceType -ObjectList $RecommendationObject -FilterList $Types.type -KeyColumn 'recommendationResourceType'
 
-    $return = $QueryObject.Where({ $_.automationavailable -eq $true -and [string]::IsNullOrEmpty($_.recommendationTypeId) }) | ForEach-Object {
+    $return = $QueryObject.Where({ $_.automationAvailable -eq $true -and [string]::IsNullOrEmpty($_.recommendationTypeId) }) | ForEach-Object {
         Write-Progress -Activity 'Running Queries' -Status "Running Query for $($_.recommendationResourceType) - $($_.aprlGuid)" -PercentComplete (($QueryObject.IndexOf($_) / $QueryObject.Count) * 100) -Id 1
         try {
-            Invoke-WAFQuery -Query $_.query -SubscriptionIds $subscriptionIds -ErrorAction Stop
+            Invoke-WAFQuery -Query $_.query -SubscriptionIds $SubscriptionIds -ErrorAction Stop
         }
         catch {
             Write-Host "Error running query for - $($_.recommendationResourceType) - $($_.aprlGuid)"
@@ -203,6 +212,8 @@ function Invoke-WAFQueryLoop {
 function Get-WAFResourceType {
     [CmdletBinding()]
     param (
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
         [string[]] $SubscriptionIds
     )
 
@@ -241,10 +252,10 @@ function Get-WAFQueryByResourceType {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [array] $ObjectList,
+        [PSCustomObject[]] $ObjectList,
 
         [Parameter(Mandatory = $true)]
-        [array] $FilterList,
+        [string[]] $FilterList,
 
         [Parameter(Mandatory = $true)]
         [string] $KeyColumn

--- a/src/modules/wara/scope/scope.psm1
+++ b/src/modules/wara/scope/scope.psm1
@@ -278,24 +278,29 @@ function Get-WAFImplicitSubscriptionId {
 function Get-WAFFilteredResourceList {
     [CmdletBinding()]
     param (
-        [array] $SubscriptionFilters = @(),
+        [Parameter(Mandatory = $false)]
+        [string[]] $SubscriptionFilters = @(),
 
-        [array] $ResourceGroupFilters = @(),
+        [Parameter(Mandatory = $false)]
+        [string[]] $ResourceGroupFilters = @(),
 
-        [array] $ResourceFilters = @(),
+        [Parameter(Mandatory = $false)]
+        [string[]] $ResourceFilters = @(),
 
+        [Parameter(Mandatory = $true)]
         [array] $UnfilteredResources,
 
+        [Parameter(Mandatory = $false)]
         [string] $KeyColumn = 'Id'
     )
 
     # TODO: ADD FILTERS FOR TAGS
 
-    $SubscriptionFilters ? $($SubscriptionFilteredResources = Get-WAFSubscriptionsByList -ObjectList $UnfilteredResources -FilterList $SubscriptionFilters -KeyColumn $KeyColumn) : $(Write-Debug "Subscription Filters not provided.")
+    $SubscriptionFilters ? $($SubscriptionFilteredResources = Get-WAFSubscriptionsByList -ObjectList $UnfilteredResources -FilterList $SubscriptionFilters -KeyColumn $KeyColumn) : $(Write-Debug 'Subscription Filters not provided.')
 
-    $ResourceGroupFilters ? $($ResourceGroupFilteredResources = Get-WAFResourceGroupsByList -ObjectList $UnfilteredResources -FilterList $ResourceGroupFilters -KeyColumn $KeyColumn) : $(Write-Debug "Resource Group Filters not provided.")
+    $ResourceGroupFilters ? $($ResourceGroupFilteredResources = Get-WAFResourceGroupsByList -ObjectList $UnfilteredResources -FilterList $ResourceGroupFilters -KeyColumn $KeyColumn) : $(Write-Debug 'Resource Group Filters not provided.')
 
-    $ResourceFilters ? $($ResourceFilteredResources = Get-WAFResourcesByList -ObjectList $UnfilteredResources -FilterList $ResourceFilters -KeyColumn $KeyColumn) : $(Write-Debug "Resource Filters not provided.")
+    $ResourceFilters ? $($ResourceFilteredResources = Get-WAFResourcesByList -ObjectList $UnfilteredResources -FilterList $ResourceFilters -KeyColumn $KeyColumn) : $(Write-Debug 'Resource Filters not provided.')
 
     # Originally used to remove duplicates but there was some weird interaction with the return object that caused it to duplicate the entire array. 
     $FilteredResources = $SubscriptionFilteredResources + $ResourceGroupFilteredResources + $ResourceFilteredResources | Select-Object -Property * -Unique

--- a/src/modules/wara/servicehealth/servicehealth.psm1
+++ b/src/modules/wara/servicehealth/servicehealth.psm1
@@ -3,6 +3,8 @@ using module ../utils/utils.psd1
 function Get-WAFServiceHealth {
     [CmdletBinding()]
     param (
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
         [string[]] $SubscriptionIds
     )
 
@@ -25,7 +27,9 @@ function Get-WAFServiceHealth {
 
 function Build-WAFServiceHealthObject {
     param (
-        $AdvQueryResult
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [PSCustomObject[]] $AdvQueryResult
     )
 
     $return = $AdvQueryResult.ForEach({ [ServiceHealthAlert]::new($_) })

--- a/src/modules/wara/utils/utils.psm1
+++ b/src/modules/wara/utils/utils.psm1
@@ -1,7 +1,11 @@
 function Invoke-WAFQuery {
     [CmdletBinding()]
     param (
+        [Parameter(Mandatory = $false)]
+        [AllowEmptyCollection()]
         [string[]] $SubscriptionIds,
+
+        [Parameter(Mandatory = $false)]
         [string] $Query = 'resources | project name, type, location, resourceGroup, subscriptionId, id'
     )
 
@@ -21,7 +25,7 @@ function Invoke-WAFQuery {
     $allResources += $result
 
     # Output all resources
-    return $allResources
+    return ,$allResources
 }
 
 <#
@@ -346,6 +350,7 @@ function Connect-WAFAzure {
         [Parameter(Mandatory = $true)]
         [GUID] $TenantID,
 
+        [Parameter(Mandatory = $false)]
         [ValidateSet('AzureCloud', 'AzureChinaCloud', 'AzureGermanCloud', 'AzureUSGovernment')]
         [string] $AzureEnvironment = 'AzureCloud'
     )
@@ -359,6 +364,7 @@ function Connect-WAFAzure {
 function Test-WAFTagPattern {
     [CmdletBinding()]
     param (
+        [Parameter(Mandatory = $true)]
         [string[]] $InputValue
     )
 
@@ -378,6 +384,7 @@ function Test-WAFTagPattern {
 function Test-WAFResourceGroupId {
     [CmdletBinding()]
     param (
+        [Parameter(Mandatory = $true)]
         [string[]] $InputValue
     )
 
@@ -397,6 +404,7 @@ function Test-WAFResourceGroupId {
 function Test-WAFSubscriptionId {
     [CmdletBinding()]
     param (
+        [Parameter(Mandatory = $true)]
         [string[]] $InputValue
     )
 
@@ -429,6 +437,8 @@ function Test-WAFIsGuid {
 
 function Repair-WAFSubscriptionId {
     [CmdletBinding()]
+    [Parameter(Mandatory = $true)]
+    [AllowEmptyCollection()]
     param (
         [string[]] $SubscriptionIds
     )

--- a/src/modules/wara/wara.psm1
+++ b/src/modules/wara/wara.psm1
@@ -146,12 +146,12 @@ function Start-WARACollector {
 
         #Get all tagged resource groups from the Implicit Subscription ID scope
         Write-Debug 'Getting all tagged resource groups from the Implicit Subscription ID scope'
-        $Filter_TaggedResourceGroupIds = Get-WAFTaggedResourceGroup -tagArray $Scope_Tags -SubscriptionIds $Scope_ImplicitSubscriptionIds.replace('/subscriptions/', '')
+        $Filter_TaggedResourceGroupIds = Get-WAFTaggedResourceGroup -TagArray $Scope_Tags -SubscriptionIds $Scope_ImplicitSubscriptionIds.replace('/subscriptions/', '')
         Write-Debug "Count of Tagged Resource Group Ids: $($Filter_TaggedResourceGroupIds.count)"
 
         #Get all tagged resources from the Implicit Subscription ID scope
         Write-Debug 'Getting all tagged resources from the Implicit Subscription ID scope'
-        $Filter_TaggedResourceIds = Get-WAFTaggedResource -tagArray $Scope_Tags -SubscriptionIds $Scope_ImplicitSubscriptionIds.replace('/subscriptions/', '')
+        $Filter_TaggedResourceIds = Get-WAFTaggedResource -TagArray $Scope_Tags -SubscriptionIds $Scope_ImplicitSubscriptionIds.replace('/subscriptions/', '')
         Write-Debug "Count of Tagged Resource Ids: $($Filter_TaggedResourceIds.count)"
 
         #Filter impactedResourceObj objects by tagged resource group and resource scope


### PR DESCRIPTION
# Overview/Summary

Add explicit data type to parameters.

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
