### PR TITLE
fix: Suppress output of Connect-AzAccount

### DIFF
--- a/src/modules/wara/utils/utils.psm1
+++ b/src/modules/wara/utils/utils.psm1
@@ -357,7 +357,7 @@ function Connect-WAFAzure {
 
     # Connect To Azure Tenant
     if ((Get-AzContext).Tenant.Id -ne $TenantID) {
-        Connect-AzAccount -Tenant $TenantID -WarningAction SilentlyContinue -Environment $AzureEnvironment
+        Connect-AzAccount -Tenant $TenantID -WarningAction SilentlyContinue -Environment $AzureEnvironment | Out-Null
     }
 }
 


### PR DESCRIPTION
# Overview/Summary

Suppress the output of Connect-AzAccount.

Connect-AzAccount returns the tenant and subscription information that switch to. This PR fixed (suppressed) it.

![image](https://github.com/user-attachments/assets/b8ae62c8-aca1-48eb-a934-5ade341fae2d)

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
