### PR TITLE
fix: Parameter validation

### DIFF
--- a/src/modules/wara/collector/collector.psm1
+++ b/src/modules/wara/collector/collector.psm1
@@ -176,7 +176,7 @@ function Invoke-WAFQueryLoop {
 
     $QueryObject = Get-WAFQueryByResourceType -ObjectList $RecommendationObject -FilterList $Types.type -KeyColumn 'recommendationResourceType'
 
-    $return = $QueryObject.Where({ $_.automationAvailable -eq $true -and [string]::IsNullOrEmpty($_.recommendationTypeId) }) | ForEach-Object {
+    $return = $QueryObject.Where({ $_.automationAvailable -eq $true -and $_.recommendationMetadataState -eq "Active" -and [string]::IsNullOrEmpty($_.recommendationTypeId) }) | ForEach-Object {
         Write-Progress -Activity 'Running Queries' -Status "Running Query for $($_.recommendationResourceType) - $($_.aprlGuid)" -PercentComplete (($QueryObject.IndexOf($_) / $QueryObject.Count) * 100) -Id 1
         try {
             (Invoke-WAFQuery -Query $_.query -SubscriptionIds $subscriptionIds -ErrorAction Stop)

--- a/src/modules/wara/wara.psm1
+++ b/src/modules/wara/wara.psm1
@@ -71,6 +71,18 @@ function Start-WARACollector {
         }
         'Default' {
             Write-Debug 'Using Default parameter set'
+
+            Write-Debug "Parameter set values: $($PSBoundParameters.Keys)"
+
+           if($PSBoundParameters.keys.contains( 'SubscriptionIds') -or $PSBoundParameters.keys.contains('ResourceGroups')) {
+                Write-Debug "We contain the parameters."
+            }
+            else{
+                Write-Debug "We do not contain the parameters."
+                throw "The parameter SubscriptionIds or ResourceGroups is required when using the Default parameter set."
+            }        
+            
+            
         }
     }
 
@@ -110,7 +122,7 @@ function Start-WARACollector {
     Write-Debug 'Creating HashTable of all resources for faster lookup'
     $AllResourcesHash = @{}
     $AllResources.ForEach({ $AllResourcesHash[$_.id] = $_ })
-    Write-Debug "All Resources Hash: $($AllResourcesHash).count"
+    Write-Debug "All Resources Hash: $($AllResourcesHash.count)"
 
     #Get all APRL recommendations from the Implicit Subscription ID scope
     Write-Debug 'Getting all APRL recommendations from the Implicit Subscription ID scope'


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Resolve issue with subscriptionid or resourcegroup not being present with -tenantid

## Related Issues/Work Items

closes #51 

<!--
- To associate a GitHub Issue, use a [key word](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with the GitHub issue number.
- To associate an ADO Work Item (internal Microsoft team member), use the key word `AB#` succeeded with the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->


- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
