### PR TITLE
fix: Fix to use wrong variable

### DIFF
--- a/src/modules/wara/wara.psm1
+++ b/src/modules/wara/wara.psm1
@@ -115,7 +115,7 @@ function Start-WARACollector {
 
     #Get all resources from the Implicit Subscription ID scope - We use this later to add type, location, subscriptionid, resourcegroup to the impactedResourceObj objects
     Write-Debug 'Getting all resources from the Implicit Subscription ID scope'
-    $AllResources = Invoke-WAFQuery -SubscriptionIds $Scope_SubscriptionIds.replace('/subscriptions/', '')
+    $AllResources = Invoke-WAFQuery -SubscriptionIds $Scope_ImplicitSubscriptionIds.replace('/subscriptions/', '')
     Write-Debug "Count of Resources: $($AllResources.count)"
 
     #Create HashTable of all resources for faster lookup


### PR DESCRIPTION
# Overview/Summary

Fix to use a wrong variable.

## Related Issues/Work Items

- Fix #54 

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
