### PR TITLE
fix: Fix return data type as an array even if only a single element

### DIFF
--- a/src/modules/wara/wara.psm1
+++ b/src/modules/wara/wara.psm1
@@ -512,7 +512,7 @@ function Build-ImpactedResourceObj {
     $impactedResourceObj = [impactedResourceFactory]::new($ImpactedResources, $AllResources, $RecommendationObject)
     $r = $impactedResourceObj.createImpactedResourceObjects()
 
-    return $r
+    return ,$r
 }
 
 function Build-ValidationResourceObj {
@@ -531,7 +531,7 @@ function Build-ValidationResourceObj {
     $validatorObj = [validationResourceFactory]::new($RecommendationObject, $validationResources, $TypesNotInAPRLOrAdvisor)
     $r = $validatorObj.createValidationResourceObjects()
 
-    return $r
+    return ,$r
 }
 
 function Build-ResourceTypeObj {
@@ -546,7 +546,7 @@ function Build-ResourceTypeObj {
 
     $return = [resourceTypeFactory]::new($ResourceObj, $TypesNotInAPRLOrAdvisor).createResourceTypeObjects()
 
-    return $return
+    return ,$return
 }
 
 function Build-SpecializedResourceObj {
@@ -561,7 +561,7 @@ function Build-SpecializedResourceObj {
 
     $return = [specializedResourceFactory]::new($SpecializedResourceObj, $RecommendationObject).createSpecializedResourceObjects()
 
-    return $return
+    return ,$return
 }
 
 function Get-WARAOtherRecommendations {
@@ -579,7 +579,7 @@ function Get-WARAOtherRecommendations {
     #Returns recommendations that are in APRL but not in Advisor under 'HighAvailability'
     $return = $RecommendationObject.recommendationTypeId | Where-Object { $_ -in $metadata }
 
-    return $return
+    return ,$return
 }
 
 


### PR DESCRIPTION
# Overview/Summary

Fix return data type as an array even if only a single element.

## Related Issues/Work Items

None

### Breaking Changes

None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
