### PR TITLE
feat: Add required modules to wara's manifest

### DIFF
--- a/src/modules/wara/wara.psd1
+++ b/src/modules/wara/wara.psd1
@@ -50,7 +50,10 @@
     # ProcessorArchitecture = ''
 
     # Modules that must be imported into the global environment prior to importing this module
-    # RequiredModules = @()
+    RequiredModules = @(
+        @{ ModuleName = 'Az.Accounts'; ModuleVersion = '3.0.0' },
+        @{ ModuleName = 'Az.ResourceGraph'; ModuleVersion = '1.0.0' }
+    )
 
     # Assemblies that must be loaded prior to importing this module
     # RequiredAssemblies = @()


### PR DESCRIPTION
# Overview/Summary

Add required modules for install those as dependency when install the wara module because Install-Module cmdlet installs dependency modules if those specified in the manifest file as RequiredModules.

## Related Issues/Work Items

None

### Breaking Changes

None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
