### PR TITLE
fix: add check for clipboard history

### DIFF
--- a/src/modules/wara/reports/3_wara_reports_generator.ps1
+++ b/src/modules/wara/reports/3_wara_reports_generator.ps1
@@ -50,6 +50,16 @@ if (-not $IsWindows) {
   Write-Host 'This script only supports Windows operating systems currently. Please try to run with Windows operating systems.'
   Exit
   }
+
+  # Check if Clipboard History is enabled
+$clipboardHistory = Get-ItemProperty -Path "HKCU:\Software\Microsoft\Clipboard" -Name "EnableClipboardHistory" -ErrorAction SilentlyContinue
+
+if ($clipboardHistory.EnableClipboardHistory -eq 1) {
+    Throw "Clipboard History is enabled. Please disable Clipboard History before running this script."
+} else {
+    Write-Debug "Clipboard History is disabled."
+}
+
 # TODO: Remove if not needed
 <# $CurrentPath = Get-Location
 $CurrentPath = $CurrentPath.Path #>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

This adds a check to reports generator to see if clipboard history is enabled. If it is, it throws an error. Clipboard history will break the PPT generation.

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
