### PR TITLE
refactor: Change parameter name for recommendations.json to consistency

### DIFF
--- a/docs/wara/Start-WARAAnalyzer.md
+++ b/docs/wara/Start-WARAAnalyzer.md
@@ -13,7 +13,7 @@ Well-Architected Reliability Assessment Script
 ## SYNTAX
 
 ```
-Start-WARAAnalyzer [[-RecommendationsUrl] <String>] [-JSONFile] <String> [[-ExpertAnalysisFile] <String>]
+Start-WARAAnalyzer [[-RecommendationDataUri] <String>] [-JSONFile] <String> [[-ExpertAnalysisFile] <String>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
@@ -34,7 +34,7 @@ Start-WARAAnalyzer -JSONFile 'C:\Temp\WARA_File_2024-04-01_10_01.json' -Debug
 
 ## PARAMETERS
 
-### -RecommendationsUrl
+### -RecommendationDataUri
 This is the URL to the JSON file that contains the recommendations. The default value is the URL to the recommendations object stored at https://azure.github.io/WARA-Build/objects/recommendations.json
 
 ```yaml

--- a/src/modules/wara/analyzer/2_wara_data_analyzer.ps1
+++ b/src/modules/wara/analyzer/2_wara_data_analyzer.ps1
@@ -28,7 +28,7 @@ https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2
 
 Param(
 [ValidatePattern('^https:\/\/.+$')]
-[string] $RecommendationsUrl = 'https://azure.github.io/WARA-Build/objects/recommendations.json',
+[string] $RecommendationDataUri = 'https://azure.github.io/WARA-Build/objects/recommendations.json',
 [Parameter(mandatory = $true)]
 [string] $JSONFile,
 [string] $ExpertAnalysisFile
@@ -220,11 +220,10 @@ function Get-WARARecommendationList
 {
     Param(
         [Parameter(Mandatory = $true)]
-        [string]$RecommendationsUrl
+        [string]$RecommendationDataUri
     )
 	Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Processing Recommendations from JSON file.')
 	# Get Recommendation Objects
-    $RecommendationDataUri = $RecommendationsUrl
     $RecommendationObject = Invoke-RestMethod $RecommendationDataUri
 
 	return $RecommendationObject
@@ -353,11 +352,11 @@ function Initialize-WARAImpactedResources
 		$ScriptDetails,
         [Parameter(mandatory = $true)]
         [AllowEmptyCollection()]
-        $RecommendationsUrl
+        $RecommendationDataUri
 	)
 
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Getting All Recommendations')
-	$RecommendationObject = Get-WARARecommendationList -RecommendationsUrl $RecommendationsUrl
+	$RecommendationObject = Get-WARARecommendationList -RecommendationDataUri $RecommendationDataUri
 
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Getting Recommendations from the standard Resources')
     $ResourceRecommendations = $RecommendationObject | Where-Object {[string]::IsNullOrEmpty($_.tags)}
@@ -1121,7 +1120,7 @@ $ExpertAnalysisTemplate = Open-ExcelPackage -Path $ExpertAnalysisFile
 
 Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Invoking Function: Initialize-WARAImpactedResources')
 # Creating the Array with the Impacted Resources to be added to the Excel file
-$ImpactedResources 	= Initialize-WARAImpactedResources -ImpactedResources $JSONContent.ImpactedResources -Advisory $JSONContent.Advisory -Retirements $JSONContent.Retirements -ScriptDetails $JSONContent.ScriptDetails -RecommendationsUrl $RecommendationsUrl
+$ImpactedResources 	= Initialize-WARAImpactedResources -ImpactedResources $JSONContent.ImpactedResources -Advisory $JSONContent.Advisory -Retirements $JSONContent.Retirements -ScriptDetails $JSONContent.ScriptDetails -RecommendationDataUri $RecommendationDataUri
 
 Write-Host $ImpactedResourcesSheetRef -NoNewline -ForegroundColor Green
 Write-Host ': ' -NoNewline

--- a/src/modules/wara/analyzer/analyzer.psm1
+++ b/src/modules/wara/analyzer/analyzer.psm1
@@ -24,7 +24,7 @@ function Start-WARAAnalyzer {
     [CmdletBinding()]
     param (
         [ValidatePattern('^https:\/\/.+$')]
-        [string] $RecommendationsUrl = 'https://azure.github.io/WARA-Build/objects/recommendations.json',
+        [string] $RecommendationDataUri = 'https://azure.github.io/WARA-Build/objects/recommendations.json',
         [Parameter(mandatory = $true)]
         [string] $JSONFile,
         [string] $ExpertAnalysisFile


### PR DESCRIPTION
# Overview/Summary

Change the parameter name for recommendations.json for consistency.

Start-WARACollector uses `RecommendationDataUri` for the parameter name to recommendations.json. But Start-WARAAnalyzer
uses `RecommendationsUrl` for it. This is inconsistency between cmdlets. We should use the same name for the same meaning parameters.

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
