### PR TITLE
refactor: Change Measure-Command to Stopwatch

### DIFF
--- a/src/modules/wara/reports/3_wara_reports_generator.ps1
+++ b/src/modules/wara/reports/3_wara_reports_generator.ps1
@@ -103,9 +103,6 @@ if (!$WorkloadName) {
 
 $TableStyle = 'Light19'
 
-$Runtime = Measure-Command -Expression {
-
-
   ######################## REGULAR Functions ##########################
 
   function Test-ReviewedRecommendations {
@@ -1266,6 +1263,9 @@ $Runtime = Measure-Command -Expression {
 
   }
 
+  # Start the stopwatch to time the script
+  $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
   #Call the functions
   $Version = "2.1.5"
   Write-Host "Version: " -NoNewline
@@ -1381,17 +1381,16 @@ $Runtime = Measure-Command -Expression {
   Get-Process -Name "POWERPNT" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process
 
   Write-Progress -Id 1 -activity "Processing Office Apps" -Status "90% Complete." -PercentComplete 90
-}
 
 Write-Progress -Id 1 -activity "Processing Office Apps" -Status "100% Complete." -Completed
-$TotalTime = $Runtime.Totalminutes.ToString('#######.##')
+
+$stopwatch.Stop()
 
 ################ Finishing
 
 Write-Host "---------------------------------------------------------------------"
 Write-Host ('Execution Complete. Total Runtime was: ') -NoNewline
-Write-Host $TotalTime -NoNewline -ForegroundColor Cyan
-Write-Host (' Minutes')
+Write-Host $stopwatch.Elapsed.toString('hh\:mm\:ss') -ForegroundColor Cyan
 Write-Host 'PowerPoint File Saved as: ' -NoNewline
 Write-Host $PPTFinalFile -ForegroundColor Cyan
 Write-Host 'Assessment Findings File Saved as: ' -NoNewline


### PR DESCRIPTION
# Overview/Summary

Changes the elapsed time measuring method from Measure-Command to Stopwatch in 3_wara_reports_generator.ps1. Because it is difficult to handle exceptions in the script block of Measure-Command.

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
