### PR TITLE
fix: parameter sets

### DIFF
--- a/src/modules/wara/wara.psm1
+++ b/src/modules/wara/wara.psm1
@@ -100,44 +100,47 @@ function Start-WARACollector {
         [switch] $PassThru,
 
         [Parameter(ParameterSetName = 'Default')]
+        [Parameter(ParameterSetName = 'Specialized')]
         [ValidateScript({ Test-WAFSubscriptionId $_ })]
         [string[]] $SubscriptionIds,
 
         [Parameter(ParameterSetName = 'Default')]
+        [Parameter(ParameterSetName = 'Specialized')]
         [ValidateScript({ Test-WAFResourceGroupId $_ })]
         [string[]] $ResourceGroups,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Default')]
+        [Parameter(ParameterSetName = 'Specialized')]
         [ValidateScript({ Test-WAFIsGuid $_ })]
         [GUID] $TenantID,
 
         [Parameter(ParameterSetName = 'Default')]
+        [Parameter(ParameterSetName = 'Specialized')]
         [ValidateScript({ Test-WAFTagPattern $_ })]
         [string[]] $Tags,
 
         [Parameter(ParameterSetName = 'Default')]
+        [Parameter(ParameterSetName = 'Specialized')]
+        [Parameter(ParameterSetName = 'ConfigFileSet')]
         [ValidateSet('AzureCloud', 'AzureUSGovernment', 'AzureGermanCloud', 'AzureChinaCloud')]
         [string] $AzureEnvironment = 'AzureCloud',
 
+        [Parameter(ParameterSetName = 'Specialized')]
         [Parameter(ParameterSetName = 'ConfigFileSet', Mandatory = $true)]
         [ValidateScript({ Test-Path $_ -PathType Leaf })]
         [string] $ConfigFile,
 
         [Parameter(ParameterSetName = 'Default')]
+        [Parameter(ParameterSetName = 'Specialized')]
+        [Parameter(ParameterSetName = 'ConfigFileSet')]
         [ValidatePattern('^https:\/\/.+$')]
         [string] $RecommendationDataUri = 'https://azure.github.io/WARA-Build/objects/recommendations.json',
 
         [Parameter(ParameterSetName = 'Default')]
+        [Parameter(ParameterSetName = 'Specialized')]
+        [Parameter(ParameterSetName = 'ConfigFileSet')]
         [ValidatePattern('^https:\/\/.+$')]
-        [string] $RecommendationResourceTypesUri = 'https://raw.githubusercontent.com/Azure/Azure-Proactive-Resiliency-Library-v2/refs/heads/main/tools/WARAinScopeResTypes.csv',
-
-        # Runbook parameters...
-        [Parameter(ParameterSetName = 'Default')]
-        [switch] $UseImplicitRunbookSelectors,
-
-        [Parameter(ParameterSetName = 'Default')]
-        [ValidateScript({ Test-Path $_ -PathType Leaf })]
-        [string] $RunbookFile
+        [string] $RecommendationResourceTypesUri = 'https://raw.githubusercontent.com/Azure/Azure-Proactive-Resiliency-Library-v2/refs/heads/main/tools/WARAinScopeResTypes.csv'
     )
 
     # Check for module updates and throw an error if the module is out of date.

--- a/src/tests/wara/wara.tests.ps1
+++ b/src/tests/wara/wara.tests.ps1
@@ -28,6 +28,12 @@ Describe 'Start-WARACollector' {
             $scriptBlock | Should -Throw
         }
     }
+    Context 'Different Parameter Sets' {
+        It 'Should throw an exception when parameters from both sets are provided' {
+            $scriptBlock = { Start-WARACollector -TenantID $(new-guid).guid -ConfigFile 'C:\invalid\path\config.json' -SubscriptionIds '/subscriptions/11111111-1111-1111-111111111111' }
+            $scriptBlock | Should -Throw
+        }
+    }
     Context 'When given correct parameters with -passthru'{
         BeforeAll {
             $AllResources_TestData = get-content "$PSScriptRoot/../data/wara/test_allresourcesdata.json" -raw | ConvertFrom-Json -depth 20


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Fixes issue with specialized parameter sets not being supported with config files.

## Related Issues/Work Items

#95 

### Breaking Changes

none

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
