### PR TITLE
Fix/parameter sets 2

### DIFF
--- a/src/modules/wara/wara.psm1
+++ b/src/modules/wara/wara.psm1
@@ -125,7 +125,6 @@ function Start-WARACollector {
         [ValidateSet('AzureCloud', 'AzureUSGovernment', 'AzureGermanCloud', 'AzureChinaCloud')]
         [string] $AzureEnvironment = 'AzureCloud',
 
-        [Parameter(ParameterSetName = 'Specialized')]
         [Parameter(ParameterSetName = 'ConfigFileSet', Mandatory = $true)]
         [ValidateScript({ Test-Path $_ -PathType Leaf })]
         [string] $ConfigFile,

--- a/src/tests/data/wara/test_configfiledata.txt
+++ b/src/tests/data/wara/test_configfiledata.txt
@@ -1,0 +1,20 @@
+#This is a test config file and none of these GUIDs are real.
+[tenantid]
+36edfaa6-8599-453d-8301-0497588f6d40
+
+[subscriptionIds]
+/subscriptions/9ca26269-2fc6-4e0f-8309-1d5e134ece42
+
+[resourcegroups]
+/subscriptions/9ca26269-2fc6-4e0f-8309-1d5e134ece42/resourceGroups/RG-01
+/subscriptions/9ca26269-2fc6-4e0f-8309-1d5e134ece42/resourceGroups/RG-02
+/subscriptions/9ca26269-2fc6-4e0f-8309-1d5e134ece42/resourceGroups/RG-03
+/subscriptions/9ca26269-2fc6-4e0f-8309-1d5e134ece42/resourceGroups/RG-04
+/subscriptions/9ca26269-2fc6-4e0f-8309-1d5e134ece42/resourceGroups/RG-05
+/subscriptions/9ca26269-2fc6-4e0f-8309-1d5e134ece42/resourceGroups/RG-06
+/subscriptions/9ca26269-2fc6-4e0f-8309-1d5e134ece42/resourceGroups/RG-07
+/subscriptions/9ca26269-2fc6-4e0f-8309-1d5e134ece42/resourceGroups/RG-08
+
+[tags]
+env||environment=~preprod
+app||application!~app1||app2

--- a/src/tests/wara/wara.tests.ps1
+++ b/src/tests/wara/wara.tests.ps1
@@ -3,6 +3,43 @@ BeforeAll {
     Import-Module -Name $modulePath -Force
 }
 
+Describe 'Start-WARACollector Parameter Sets' {
+    BeforeAll {
+
+        Mock Start-WARACollector {return $null} -Verifiable -RemoveParameterValidation "TenantID","SubscriptionIds","ConfigFile","ResourceGroups"
+    }
+    Context 'ConfigFile' {
+        It 'Should proceed when used alone.' {
+            $result = Start-WARACollector -ConfigFile "$PSScriptRoot/../data/wara/test_configfiledata.txt"
+            Assert-MockCalled Start-WARACollector -Exactly 1 -Scope It
+        }
+    }
+    Context 'ConfigFile + Specialized' {
+        It 'Should proceed with ConfigFile + Specialized.' {
+            $result = Start-WARACollector -ConfigFile "$PSScriptRoot/../data/wara/test_configfiledata.txt" -SAP -AVS -AVD -HPC -AI_GPT_RAG
+            Assert-MockCalled Start-WARACollector -Exactly 1 -Scope It
+        }
+    }
+    Context 'TenantId + SubscriptionIds' {
+        It 'Should proceed with TenantId + SubscriptionIds' {
+            $result = Start-WARACollector -TenantID $(New-Guid).Guid -SubscriptionIds '/subscriptions/11111111-1111-1111-111111111111'
+            Assert-MockCalled Start-WARACollector -Exactly 1 -Scope It
+        }
+    }
+    Context 'TenantId + SubscriptionIds + ResourceGroups' {
+        It 'Should proceed with TenantId + SubscriptionIds + ResourceGroups' {
+            $result = Start-WARACollector -TenantID $(New-Guid).Guid -SubscriptionIds '/subscriptions/11111111-1111-1111-111111111111' -ResourceGroups 'RG1'
+            Assert-MockCalled Start-WARACollector -Exactly 1 -Scope It
+        }
+    }
+    Context 'TenantId + SubscriptionIds + ResourceGroups + Specialized' {
+        It 'Should proceed with TenantId + SubscriptionIds + ResourceGroups + Specialized' {
+            $result = Start-WARACollector -TenantID $(New-Guid).Guid -SubscriptionIds '/subscriptions/11111111-1111-1111-111111111111' -ResourceGroups 'RG1'
+            Assert-MockCalled Start-WARACollector -Exactly 1 -Scope It
+        }
+    }
+}
+
 Describe 'Start-WARACollector' {
     Context 'When given the Default parameter set without SubscriptionIds and ResourceGroups' {
         It 'Should throw an exception with the specified message' {

--- a/src/tests/wara/wara.tests.ps1
+++ b/src/tests/wara/wara.tests.ps1
@@ -34,7 +34,7 @@ Describe 'Start-WARACollector Parameter Sets' {
     }
     Context 'TenantId + SubscriptionIds + ResourceGroups + Specialized' {
         It 'Should proceed with TenantId + SubscriptionIds + ResourceGroups + Specialized' {
-            $result = Start-WARACollector -TenantID $(New-Guid).Guid -SubscriptionIds '/subscriptions/11111111-1111-1111-111111111111' -ResourceGroups 'RG1'
+            $result = Start-WARACollector -TenantID $(New-Guid).Guid -SubscriptionIds '/subscriptions/11111111-1111-1111-111111111111' -ResourceGroups 'RG1' -SAP -AVS -AVD -HPC -AI_GPT_RAG
             Assert-MockCalled Start-WARACollector -Exactly 1 -Scope It
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Fixes issue with parameter sets not allow configfile to work properly.
Adds tests for parameter sets for WARA validation.

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
