### PR TITLE
Release/0.0.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ This repository holds scripts and automation built for the Well-Architected Reli
 
 ### Patch Notes
 
+- **Version 0.0.21**
+  - Fixes issue with Start-WARACollector not running when -ConfigFile was being passed due to added parameter set on the ConfigFile parameter.
+  - Added tests for parameter set testing to prevent this from happening again.
+
 - **Version 0.0.20**
   - Fixes performance issue with Get-WAFFilteredResources.
     - The function was not optimized for performance and was spending too much time processing scope. This has been fixed by changing how we filter resources. The function now uses Sort-Object | Get-Unique -AsString to filter resources and resulted in a significant performance improvement. The function now runs in a few milliseconds compared to a few minutes when collections were greater than 10,000 resources.

--- a/src/modules/wara/wara.psd1
+++ b/src/modules/wara/wara.psd1
@@ -11,7 +11,7 @@
     RootModule        = 'wara.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.0.20'
+    ModuleVersion     = '0.0.21'
 
     # Supported PSEditions
     CompatiblePSEditions = 'Core'


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Releases 0.0.21
- Fixes issue with parameter sets not allowing -ConfigFile to be specified.
- Adds tests for parameter sets to prevent future issues.

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
