### PR TITLE
Fix/advisor filtering issue

### DIFF
--- a/src/modules/wara/scope/scope.psm1
+++ b/src/modules/wara/scope/scope.psm1
@@ -311,6 +311,6 @@ function Get-WAFFilteredResourceList {
 
     #$FilteredResources += $SubscriptionFilteredResources + $ResourceGroupFilteredResources + $ResourceFilteredResources | Sort-Object | Get-Unique -CaseInsensitive -AsString
     $FilteredResources += $SubscriptionFilteredResources + $ResourceGroupFilteredResources + $ResourceFilteredResources
-    $FilteredResources = Get-unique -InputObject $FilteredResources
+    $FilteredResources = Get-unique -InputObject $FilteredResources -CaseInsensitive
     return ,$FilteredResources
 }

--- a/src/modules/wara/scope/scope.psm1
+++ b/src/modules/wara/scope/scope.psm1
@@ -309,7 +309,8 @@ function Get-WAFFilteredResourceList {
 
     $FilteredResources = @()
 
-    $FilteredResources += $SubscriptionFilteredResources + $ResourceGroupFilteredResources + $ResourceFilteredResources | Sort-Object | Get-Unique -CaseInsensitive -AsString
-
+    #$FilteredResources += $SubscriptionFilteredResources + $ResourceGroupFilteredResources + $ResourceFilteredResources | Sort-Object | Get-Unique -CaseInsensitive -AsString
+    $FilteredResources += $SubscriptionFilteredResources + $ResourceGroupFilteredResources + $ResourceFilteredResources
+    $FilteredResources = Get-unique -InputObject $FilteredResources
     return ,$FilteredResources
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Resolves issue with advisor filtering not working as intended.


## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
