### PR TITLE
fix: remove metadata from script calls

### DIFF
--- a/src/modules/wara/wara.psm1
+++ b/src/modules/wara/wara.psm1
@@ -397,17 +397,17 @@ function Start-WARACollector {
     $impactedResourceObj += $validationResourceObj
     Write-Debug "Count of combined validationResourceObj impactedResourceObj objects: $($impactedResourceObj.count)"
 
-<#     #Get Advisor Metadata to include recommendations that are not in Advisor under 'HighAvailability'
+    #Get Advisor Metadata to include recommendations that are not in Advisor under 'HighAvailability'
     Write-Debug 'Getting Advisor Metadata'
     Write-Progress -Activity 'WARA Collector' -Status 'Getting Advisor Metadata' -PercentComplete 59 -Id 1
-    $AdvisorMetadata = Get-WAFAdvisorMetadata -ResourceURL $BaseURL
+    $null = Get-WAFAdvisorMetadata -ResourceURL $BaseURL -ErrorAction SilentlyContinue
     Write-Debug "Count of Advisor Metadata: $($AdvisorMetadata.count)"
 
     #Get Other Recommendations
     Write-Debug 'Getting Other Recommendations'
     Write-Progress -Activity 'WARA Collector' -Status 'Getting Other Recommendations' -PercentComplete 62 -Id 1
-    $OtherRecommendations = Get-WARAOtherRecommendations -RecommendationObject $RecommendationObject -AdvisorMetadata $AdvisorMetadata
-    Write-Debug "Count of Other Recommendations: $($OtherRecommendations.count)" #>
+    $null = Get-WARAOtherRecommendations -RecommendationObject $RecommendationObject -AdvisorMetadata $AdvisorMetadata -ErrorAction SilentlyContinue
+    Write-Debug "Count of Other Recommendations: $($OtherRecommendations.count)"
 
     #Get Advisor Recommendations
     Write-Debug 'Getting Advisor Recommendations'

--- a/src/modules/wara/wara.psm1
+++ b/src/modules/wara/wara.psm1
@@ -397,7 +397,7 @@ function Start-WARACollector {
     $impactedResourceObj += $validationResourceObj
     Write-Debug "Count of combined validationResourceObj impactedResourceObj objects: $($impactedResourceObj.count)"
 
-    #Get Advisor Metadata to include recommendations that are not in Advisor under 'HighAvailability'
+<#     #Get Advisor Metadata to include recommendations that are not in Advisor under 'HighAvailability'
     Write-Debug 'Getting Advisor Metadata'
     Write-Progress -Activity 'WARA Collector' -Status 'Getting Advisor Metadata' -PercentComplete 59 -Id 1
     $AdvisorMetadata = Get-WAFAdvisorMetadata -ResourceURL $BaseURL
@@ -407,12 +407,12 @@ function Start-WARACollector {
     Write-Debug 'Getting Other Recommendations'
     Write-Progress -Activity 'WARA Collector' -Status 'Getting Other Recommendations' -PercentComplete 62 -Id 1
     $OtherRecommendations = Get-WARAOtherRecommendations -RecommendationObject $RecommendationObject -AdvisorMetadata $AdvisorMetadata
-    Write-Debug "Count of Other Recommendations: $($OtherRecommendations.count)"
+    Write-Debug "Count of Other Recommendations: $($OtherRecommendations.count)" #>
 
     #Get Advisor Recommendations
     Write-Debug 'Getting Advisor Recommendations'
     Write-Progress -Activity 'WARA Collector' -Status 'Getting Advisor Recommendations' -PercentComplete 65 -Id 1
-    $advisorResourceObj = Get-WAFAdvisorRecommendation -AdditionalRecommendationIds $OtherRecommendations -SubscriptionIds $Scope_ImplicitSubscriptionIds.replace('/subscriptions/', '') -HighAvailability
+    $advisorResourceObj = Get-WAFAdvisorRecommendation -SubscriptionIds $Scope_ImplicitSubscriptionIds.replace('/subscriptions/', '') -HighAvailability
     Write-Debug "Count of Advisor Recommendations: $($advisorResourceObj.count)"
 
     #Prior to filtering, capture all "global" recommendations that are microsoft.subscriptions/subscriptions since these get filtered out.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Fixes transient issue where getting advisor metadata fails. This is no longer needed and has been removed.

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
