### PR TITLE
fix: Fix WAF recommendation's learn more link

### DIFF
--- a/src/modules/wara/analyzer/2_wara_data_analyzer.ps1
+++ b/src/modules/wara/analyzer/2_wara_data_analyzer.ps1
@@ -585,7 +585,7 @@ function Initialize-WARAImpactedResources
                     $WAFObj.Impact = $waf.recommendationImpact
                     $WAFObj.RecommendationControl = ($waf.recommendationControl -csplit '(?=[A-Z])' -ne '' -join ' ')
                     $WAFObj.PotentialBenefit = $waf.potentialBenefits
-                    $WAFObj.LearnMoreLink = ($Recom.learnMoreLink.url -join " `n")
+                    $WAFObj.LearnMoreLink = ($waf.learnMoreLink.url -join " `n")
                     $WAFObj.LongDescription = $waf.longDescription
                     $WAFObj.Guid = $waf.aprlGuid
                     $WAFObj.Category = 'Well Architected'


### PR DESCRIPTION
# Overview/Summary

The WAF recommendations have wrong learn more links. This pull request fixes that.

**The wara module 1.0.2 (With wrong learn more links):**
All WAF recommendations have the same learn more link and its wrong link.

![image](https://github.com/user-attachments/assets/9981c53a-9b30-4082-94d1-e388893109db)

**The wara module 1.0.2 with this PR (With correct learn more links):**

![image](https://github.com/user-attachments/assets/4b9d276f-6116-4c43-9e19-f391ca4cb0ca)

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
