### PR TITLE
fix: advisor resource 0 handling

### DIFF
--- a/src/modules/wara/analyzer/2_wara_data_analyzer.ps1
+++ b/src/modules/wara/analyzer/2_wara_data_analyzer.ps1
@@ -399,15 +399,15 @@ function Initialize-WARAImpactedResources
 	Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Overall Recommendations found: ' + [string]$ResourceRecommendations.Count)
 
 	# Filtering the recommendations to get only the active ones and the ones that are not already in the advisories list
-	Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Filtering Active Recommendations and Recommendations not in Advisories')
-	$RecommendationContent = $ResourceRecommendations | Where-Object {($_.recommendationMetadataState -eq 'Active' -and $_.recommendationTypeId -notin $JSONContent.Advisory.recommendationId) }
+	#Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Filtering Active Recommendations and Recommendations not in Advisories')
+	#$RecommendationContent = $ResourceRecommendations | Where-Object {($_.recommendationMetadataState -eq 'Active' -and $_.recommendationTypeId -notin $JSONContent.Advisory.recommendationId) }
 
-	Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Recommendations After Filtering: ' + [string]$RecommendationContent.Count)
+	#Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Recommendations After Filtering: ' + [string]$RecommendationContent.Count)
 
 	$tmp = @()
 
 	# First loop through the recommendations to get the impacted resources
-	foreach ($Recom in $RecommendationContent)
+	foreach ($Recom in $ResourceRecommendations)
 		{
 			# Getting the impacted resources for the recommendation and validating if the recommendation is a Custom Recommendation
 			$Resources = $ImpactedResources | Where-Object {($_.recommendationId -eq $Recom.aprlGuid) -and ($_.checkName -eq $Recom.checkName) }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Fixes issue with resources being filtered out of Expert-Analysis when the Advisory section in the JSON output is blank. This is an extreme edge case, but should be handled gracefully with this PR.

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x ] Ensured PR tests are passing
- [ x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
