### PR TITLE
fix: get-waffilteredresourcelist handles 0 recommendations

### DIFF
--- a/src/modules/wara/scope/scope.psm1
+++ b/src/modules/wara/scope/scope.psm1
@@ -292,7 +292,7 @@ function Get-WAFFilteredResourceList {
         [string[]] $ResourceFilters = @(),
 
         [Parameter(Mandatory = $true)]
-        [array] $UnfilteredResources,
+        [array] $UnfilteredResources = @(),
 
         [Parameter(Mandatory = $false)]
         [string] $KeyColumn = 'Id'
@@ -313,6 +313,11 @@ function Get-WAFFilteredResourceList {
 
     #$FilteredResources += $SubscriptionFilteredResources + $ResourceGroupFilteredResources + $ResourceFilteredResources | Sort-Object | Get-Unique -CaseInsensitive -AsString
     $FilteredResources += $SubscriptionFilteredResources + $ResourceGroupFilteredResources + $ResourceFilteredResources
+
+    if($FilteredResources.Count -eq 0){
+        Write-Debug 'No resources found matching the provided filters.'
+        return ,$FilteredResources
+    }
 
     $FilteredResources = [System.Linq.Enumerable]::Distinct([object[]]$FilteredResources).toArray()
     return ,$FilteredResources


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Fixes Get-WAFFilteredResourceList where the filtering would remove any resource resulting in a null output.

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
