### PR TITLE
fix: tick spacing

### DIFF
--- a/src/modules/wara/reports/3_wara_reports_generator.ps1
+++ b/src/modules/wara/reports/3_wara_reports_generator.ps1
@@ -362,7 +362,7 @@ $TableStyle = 'Light19'
       ($SlideHealthAndRisk.Shapes | Where-Object { $_.Id -eq 12 }).TextFrame.TextRange.Text = ' '
     }
 
-    
+
     while (($SlideHealthAndRisk.Shapes | Where-Object { $_.Id -eq 12 }).TextFrame.TextRange.Paragraphs().count -gt 5) {
       ($SlideHealthAndRisk.Shapes | Where-Object { $_.Id -eq 12 }).TextFrame.TextRange.Paragraphs(6).Delete()
     }
@@ -421,7 +421,8 @@ $TableStyle = 'Light19'
     Start-Sleep 1
 
     $Shape = $ChartSlide.Shapes | Where-Object { $_.Name -eq 'ChartP0' }
-
+    $yAxis = $Shape.Chart.Axes(1)  # 2 corresponds to xlValue for the Y-axis
+    $yAxis.TickLabelSpacing = 1
     $Shape.IncrementLeft(240)
     Start-Sleep -Milliseconds 500
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Fixes spacing so that all resource types appear on the graph in slide 16

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
