### PR TITLE
fix: ResourceType Recommendations with only Automated Queries

### DIFF
--- a/src/modules/wara/wara.psm1
+++ b/src/modules/wara/wara.psm1
@@ -968,9 +968,15 @@ class validationResourceFactory {
     [object[]] createValidationResourceObjects() {
         $return = @()
 
+        $RecommendationResourceTypesWithoutAutomation = ($this.recommendationObject | group recommendationResourceType | where {$_.group.automationavailable -notcontains $false}).Name
+
         $return = foreach ($v in $this.validationResources.GetEnumerator()) {
 
             $impactedResource = $v.value
+
+            if($impactedResource.type -in $RecommendationResourceTypesWithoutAutomation){
+                continue
+            }
 
             $recommendationByType = $this.recommendationObject.where({ $_.automationAvailable -eq $false -and $impactedResource.type -eq $_.recommendationResourceType -and $_.recommendationMetadataState -eq "Active" -and [string]::IsNullOrEmpty($_.recommendationTypeId) })
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

This PR fixes a potential issue with resource types not matching in the `validationResourceFactory` class in the `wara.psm1` file. 

The changes create a new process using the `RecommendationResourceTypesWithoutAutomation` variable where it correctly assigns and that the impacted resources are filtered based on the resource type.

## Related Issues/Work Items

When a resourcetype only has automated recommendations, the manual validation process was throwing errors behinds the scenes for logging. These errors are benign for these resource types, because we would not expect them to have manual validation resources. However, this produced noise that would block our ability to identify resource types or recommendations that may have issues.

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
