### PR TITLE
Feat/remove retirements from advisor query

### DIFF
--- a/src/modules/wara/advisor/advisor.psm1
+++ b/src/modules/wara/advisor/advisor.psm1
@@ -81,7 +81,7 @@ function Get-WAFAdvisorRecommendation {
         "advisorresources
 | where type == 'microsoft.advisor/recommendations'
 | where tostring(properties.category) in ('$categoriesString') or properties.recommendationTypeId in ('$additionalRecommendationIdsString')
-| where properties.tracked !~ 'true'
+| where properties.tracked !~ 'true' and properties.extendedProperties.recommendationControl != 'ServiceUpgradeAndRetirement'
 | extend resId = tolower(tostring(properties.resourceMetadata.resourceId))
 | join kind=leftouter (resources | project ['resId']=tolower(id), subscriptionId, resourceGroup, location, type) on resId
 | extend id = iff(properties.impactedField =~ 'microsoft.subscriptions/subscriptions', strcat('/subscriptions/', subscriptionId), resId1)

--- a/src/modules/wara/wara.psd1
+++ b/src/modules/wara/wara.psd1
@@ -11,7 +11,7 @@
     RootModule        = 'wara.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.0.4'
+    ModuleVersion     = '1.0.5'
 
     # Supported PSEditions
     CompatiblePSEditions = 'Core'
@@ -139,7 +139,7 @@
             # ReleaseNotes = ''
 
             # Prerelease string of this module
-            # Prerelease = ''
+            Prerelease = 'alpha1'
 
             # Flag to indicate whether the module requires explicit user acceptance for install/update/save
             # RequireLicenseAcceptance = $false


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

There is a new advisor recommendation type being returned for retirements. We need to discuss how to handle this in the collector so that it's clearly another a retirement, as currently they show up as a regular recommendation. This is further compounded by the fact that the original retirement recommendations from the retirement api are still in the action plan.

This PR excludes the ServiceUpgradeAndRetirement type from being returned in the advisor query.

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
