### PR TITLE
docs: Add warning for Start-WARAReport in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ The `Start-WARAReport` cmdlet is used to generate the WARA reports.
 > Whatever directory you run the `Start-WARAReport` cmdlet in, the Excel and PowerPoint files will be created in that directory. For example: if you run the `Start-WARAReport` cmdlet in the `C:\Temp` directory, the Excel and PowerPoint files will be created in the `C:\Temp` directory.
 
 You can review all of the parameters of Start-WARAReport [here](docs/wara/Start-WARAReport.md).
-
+> [!WARNING]
+> Make sure to close all instances of Microsoft Excel and PowerPoint prior to running `Start-WARAReport`
 #### Examples
 
 ##### Create the Excel and PowerPoint reports from the Action Plan Excel output

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The `Start-WARAReport` cmdlet is used to generate the WARA reports.
 
 You can review all of the parameters of Start-WARAReport [here](docs/wara/Start-WARAReport.md).
 > [!WARNING]
-> Make sure to close all instances of Microsoft Excel and PowerPoint prior to running `Start-WARAReport`
+> Make sure to close all instances of **Microsoft Excel** and **Microsoft PowerPoint** prior to running `Start-WARAReport`
 #### Examples
 
 ##### Create the Excel and PowerPoint reports from the Action Plan Excel output


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Readme docs update with: Add warning for Start-WARAReport section in README to inform user that all instances of PowerPoint and Excel should be closed prior to running Start-WARAReport.

### Breaking Changes
None

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x]Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
