### PR TITLE
Remove validate set from scripts for azure environment

### DIFF
--- a/src/modules/wara/utils/utils.psm1
+++ b/src/modules/wara/utils/utils.psm1
@@ -400,7 +400,6 @@ function Connect-WAFAzure {
         [GUID] $TenantID,
 
         [Parameter(Mandatory = $false)]
-        [ValidateSet('AzureCloud', 'AzureChinaCloud', 'AzureGermanCloud', 'AzureUSGovernment')]
         [string] $AzureEnvironment = 'AzureCloud'
     )
 

--- a/src/modules/wara/wara.psm1
+++ b/src/modules/wara/wara.psm1
@@ -133,7 +133,6 @@ function Start-WARACollector {
         [Parameter(ParameterSetName = 'Default')]
         [Parameter(ParameterSetName = 'Specialized')]
         [Parameter(ParameterSetName = 'ConfigFileSet')]
-        [ValidateSet('AzureCloud', 'AzureUSGovernment', 'AzureGermanCloud', 'AzureChinaCloud')]
         [string] $AzureEnvironment = 'AzureCloud',
 
         [Parameter(ParameterSetName = 'ConfigFileSet', Mandatory = $true)]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

This PR addresses the issue with specifying Azure Environments. We have removed the validate list and have left the default value as `AzureCloud` for both `Connect-WAFAzure` and `Start-WARACollector` functions.

This means if you need to utilize a non-default Azure Environment, you can specify it without any restrictions.

## Related Issues/Work Items

#166 

### Breaking Changes

None

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x ] Ensured PR tests are passing
- [x ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
