### PR TITLE
feat: Add better exception experience to Start-WARAReport

### DIFF
--- a/src/modules/wara/reports/3_wara_reports_generator.ps1
+++ b/src/modules/wara/reports/3_wara_reports_generator.ps1
@@ -1224,6 +1224,55 @@ function Build-ExcelPivotChart {
 
 }
 
+function New-ExceptionMessage {
+    param (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.ErrorRecord] $ErrorRecord
+    )
+
+    $ex = $ErrorRecord.Exception
+    $horizontalLineLength = 40
+
+    $builder = New-Object -TypeName 'System.Text.StringBuilder'
+    [void] $builder.AppendLine('')
+    [void] $builder.AppendLine($ex.Message)
+    [void] $builder.AppendLine('')
+
+    [void] $builder.AppendLine('*' * $horizontalLineLength)
+    [void] $builder.AppendLine('Exception                : ' + $ex.GetType().FullName)
+    [void] $builder.AppendLine('FullyQualifiedErrorId    : ' + $ErrorRecord.FullyQualifiedErrorId)
+    [void] $builder.AppendLine('ErrorDetailsMessage      : ' + $ErrorRecord.ErrorDetails.Message)
+    [void] $builder.AppendLine('CategoryInfo             : ' + $ErrorRecord.CategoryInfo.ToString())
+    [void] $builder.AppendLine('StackTrace in PowerShell :')
+    [void] $builder.AppendLine($ErrorRecord.ScriptStackTrace)
+
+    [void] $builder.AppendLine('')
+    [void] $builder.AppendLine('-------- Exception --------')
+    [void] $builder.AppendLine('Exception  : ' + $ex.GetType().FullName)
+    [void] $builder.AppendLine('Message    : ' + $ex.Message)
+    [void] $builder.AppendLine('Source     : ' + $ex.Source)
+    [void] $builder.AppendLine('HResult    : ' + $ex.HResult)
+    [void] $builder.AppendLine('StackTrace :')
+    [void] $builder.AppendLine($ex.StackTrace)
+
+    $depth = 1
+    while ($ex.InnerException) {
+        $ex = $ex.InnerException
+        [void] $builder.AppendLine('')
+        [void] $builder.AppendLine('-------- Inner Exception {0} --------' -f $depth)
+        [void] $builder.AppendLine('Exception  : ' + $ex.GetType().FullName)
+        [void] $builder.AppendLine('Message    : ' + $ex.Message)
+        [void] $builder.AppendLine('Source     : ' + $ex.Source)
+        [void] $builder.AppendLine('HResult    : ' + $ex.HResult)
+        [void] $builder.AppendLine('StackTrace :')
+        [void] $builder.AppendLine($ex.StackTrace)
+        $depth++
+    }
+
+    [void] $builder.AppendLine('*' * $horizontalLineLength)
+    return $builder.ToString()
+}
+
 ######################## Main Script Part ##########################
 
 # Start the stopwatch to time the script

--- a/src/modules/wara/reports/3_wara_reports_generator.ps1
+++ b/src/modules/wara/reports/3_wara_reports_generator.ps1
@@ -34,18 +34,121 @@ https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2
 
 Param(
   [switch] $Help,
+
   #[switch] $csvExport,
+
   [switch] $includeLow,
-  [string] $CustomerName,
-  [string] $WorkloadName,
-  [Parameter(mandatory = $true)]
+
+  [Parameter(Mandatory = $false)]
+  [string] $CustomerName = '[Customer Name]',
+
+  [Parameter(Mandatory = $false)]
+  [string] $WorkloadName = '[Workload Name]',
+
+  [Parameter(Mandatory = $true)]
   [Alias('ExcelFile')]
   [string] $ExpertAnalysisFile,
+
   [string] $AssessmentFindingsFile,
+
   [string] $PPTTemplateFile
 )
 
 $ErrorActionPreference = 'Stop'
+
+trap {
+    $ex = $_.Exception
+    $horizontalLineLength = 40
+
+    $builder = New-Object -TypeName 'System.Text.StringBuilder'
+    [void] $builder.AppendLine('')
+    [void] $builder.AppendLine($ex.Message)
+    [void] $builder.AppendLine('')
+
+    [void] $builder.AppendLine('*' * $horizontalLineLength)
+    [void] $builder.AppendLine('Exception                : ' + $ex.GetType().FullName)
+    [void] $builder.AppendLine('FullyQualifiedErrorId    : ' + $_.FullyQualifiedErrorId)
+    [void] $builder.AppendLine('ErrorDetailsMessage      : ' + $_.ErrorDetails.Message)
+    [void] $builder.AppendLine('CategoryInfo             : ' + $_.CategoryInfo.ToString())
+    [void] $builder.AppendLine('StackTrace in PowerShell :')
+    [void] $builder.AppendLine($_.ScriptStackTrace)
+
+    [void] $builder.AppendLine('')
+    [void] $builder.AppendLine('---- Exception Details ----')
+    [void] $builder.AppendLine('Exception  : ' + $ex.GetType().FullName)
+    [void] $builder.AppendLine('Message    : ' + $ex.Message)
+    [void] $builder.AppendLine('Source     : ' + $ex.Source)
+    [void] $builder.AppendLine('HResult    : ' + $ex.HResult)
+    [void] $builder.AppendLine('StackTrace :')
+    [void] $builder.AppendLine($ex.StackTrace)
+
+    $depth = 1
+    while ($ex.InnerException) {
+        $ex = $ex.InnerException
+        [void] $builder.AppendLine('')
+        [void] $builder.AppendLine('---- Inner Exception Details {0} ----' -f $depth)
+        [void] $builder.AppendLine('Exception  : ' + $ex.GetType().FullName)
+        [void] $builder.AppendLine('Message    : ' + $ex.Message)
+        [void] $builder.AppendLine('Source     : ' + $ex.Source)
+        [void] $builder.AppendLine('HResult    : ' + $ex.HResult)
+        [void] $builder.AppendLine('StackTrace :')
+        [void] $builder.AppendLine($ex.StackTrace)
+        $depth++
+    }
+
+    [void] $builder.AppendLine('*' * $horizontalLineLength)
+    $builder.ToString() | Write-Host -ForegroundColor Yellow
+
+    break
+}
+
+# Checking the operating system running this script.
+if (-not $IsWindows) {
+    throw 'This script only supports Windows operating systems currently. Please try to run with Windows operating systems.'
+}
+
+# Check if Clipboard History is enabled
+$clipboardHistory = Get-ItemProperty -Path 'HKCU:\Software\Microsoft\Clipboard' -Name 'EnableClipboardHistory' -ErrorAction SilentlyContinue
+
+if ($clipboardHistory.EnableClipboardHistory -eq 1) {
+    throw 'Clipboard History is enabled. Please disable Clipboard History before running this script. See more details at https://aka.ms/waratools/faq'
+} else {
+    Write-Debug 'Clipboard History is disabled.'
+}
+
+# Verify the PPTTemplateFile parameter
+if ($PSBoundParameters.ContainsKey('PPTTemplateFile')) {
+    # Resolve-Path throw exception if the path does not exist.
+    $pptTemplateFilePath = (Resolve-Path -LiteralPath $PPTTemplateFile).Path
+    if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
+        throw 'The specified PowerPoint template file "{0}" is not a file. Please provide the path to the PowerPoint template file.' -f $pptTemplateFilePath
+    }
+}
+else {
+    $pptTemplateFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'Mandatory - Executive Summary presentation - Template.pptx'
+    if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
+        throw 'The default PowerPoint template file "{0}" does not exist. Please contact the WARA team via https://aka.ms/waratools/issue or Microsoft Teams.' -f $pptTemplateFilePath
+    }
+}
+Write-Host ('PowerPoint Template File: {0}' -f $pptTemplateFilePath)
+
+# Verify the AssessmentFindingsFile parameter
+if ($PSBoundParameters.ContainsKey('AssessmentFindingsFile')) {
+    # Resolve-Path throw exception if the path does not exist.
+    $assessmentFindingsFilePath = (Resolve-Path -LiteralPath $AssessmentFindingsFile).Path
+    if (-not (Test-Path -PathType Leaf -LiteralPath $assessmentFindingsFilePath)) {
+        throw 'The specified Assessment Findings file "{0}" is not a file. Please provide the path to the Assessment Findings file.' -f $assessmentFindingsFilePath
+    }
+}
+else {
+    $assessmentFindingsFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'Assessment-Findings-Report-v1.xlsx'
+    if (-not (Test-Path -PathType Leaf -LiteralPath $assessmentFindingsFilePath)) {
+        throw 'The default Assessment Findings file "{0}" does not exist. Please contact the WARA team via https://aka.ms/waratools/issue or Microsoft Teams.' -f $assessmentFindingsFilePath
+    }
+}
+Write-Host ('Assessment Findings File: {0}' -f $assessmentFindingsFilePath)
+
+$TableStyle = 'Light19'
 
   ######################## REGULAR Functions ##########################
 
@@ -1224,305 +1327,190 @@ function Build-ExcelPivotChart {
 
 }
 
-function New-ExceptionMessage {
-    param (
-        [Parameter(Mandatory = $true)]
-        [System.Management.Automation.ErrorRecord] $ErrorRecord
-    )
+# Start the stopwatch to time the script
+$stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-    $ex = $ErrorRecord.Exception
-    $horizontalLineLength = 40
+#Call the functions
+$Version = "2.1.5"
+Write-Host "Version: " -NoNewline
+Write-Host $Version -ForegroundColor DarkBlue -NoNewline
+Write-Host " "
 
-    $builder = New-Object -TypeName 'System.Text.StringBuilder'
-    [void] $builder.AppendLine('')
-    [void] $builder.AppendLine($ex.Message)
-    [void] $builder.AppendLine('')
+$CoreFile = get-item -Path $ExpertAnalysisFile
+$CoreFile = $CoreFile.FullName
 
-    [void] $builder.AppendLine('*' * $horizontalLineLength)
-    [void] $builder.AppendLine('Exception                : ' + $ex.GetType().FullName)
-    [void] $builder.AppendLine('FullyQualifiedErrorId    : ' + $ErrorRecord.FullyQualifiedErrorId)
-    [void] $builder.AppendLine('ErrorDetailsMessage      : ' + $ErrorRecord.ErrorDetails.Message)
-    [void] $builder.AppendLine('CategoryInfo             : ' + $ErrorRecord.CategoryInfo.ToString())
-    [void] $builder.AppendLine('StackTrace in PowerShell :')
-    [void] $builder.AppendLine($ErrorRecord.ScriptStackTrace)
+Test-ReviewedRecommendations -ExcelFile $CoreFile
 
-    [void] $builder.AppendLine('')
-    [void] $builder.AppendLine('-------- Exception --------')
-    [void] $builder.AppendLine('Exception  : ' + $ex.GetType().FullName)
-    [void] $builder.AppendLine('Message    : ' + $ex.Message)
-    [void] $builder.AppendLine('Source     : ' + $ex.Source)
-    [void] $builder.AppendLine('HResult    : ' + $ex.HResult)
-    [void] $builder.AppendLine('StackTrace :')
-    [void] $builder.AppendLine($ex.StackTrace)
-
-    $depth = 1
-    while ($ex.InnerException) {
-        $ex = $ex.InnerException
-        [void] $builder.AppendLine('')
-        [void] $builder.AppendLine('-------- Inner Exception {0} --------' -f $depth)
-        [void] $builder.AppendLine('Exception  : ' + $ex.GetType().FullName)
-        [void] $builder.AppendLine('Message    : ' + $ex.Message)
-        [void] $builder.AppendLine('Source     : ' + $ex.Source)
-        [void] $builder.AppendLine('HResult    : ' + $ex.HResult)
-        [void] $builder.AppendLine('StackTrace :')
-        [void] $builder.AppendLine($ex.StackTrace)
-        $depth++
-    }
-
-    [void] $builder.AppendLine('*' * $horizontalLineLength)
-    return $builder.ToString()
+Write-Debug (' ---------------------------------- STARTING REPORT GENERATOR SCRIPT --------------------------------------- ')
+Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting Report Generator Script..')
+Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Script Version: ' + $Version)
+Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Excel File: ' + $ExpertAnalysisFile)
+$ImportExcel = Get-Module -Name ImportExcel -ListAvailable -ErrorAction silentlycontinue
+foreach ($IExcel in $ImportExcel) {
+    $IExcelPath = $IExcel.Path
+    $IExcelVer = [string]$IExcel.Version
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - ImportExcel Module Path: ' + $IExcelPath)
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - ImportExcel Module Version: ' + $IExcelVer)
 }
 
-######################## Main Script Part ##########################
+Write-Progress -Id 1 -activity "Processing Office Apps" -Status "10% Complete." -PercentComplete 10
+Test-Requirement
+Write-Progress -Id 1 -activity "Processing Office Apps" -Status "15% Complete." -PercentComplete 15
+#Set-LocalFile
+Write-Progress -Id 1 -activity "Processing Office Apps" -Status "20% Complete." -PercentComplete 20
+
+$ExcelImpactedResources = Get-ExcelImpactedResources -ExcelFile $CoreFile
+
+Write-Progress -Id 1 -activity "Processing Office Apps" -Status "25% Complete." -PercentComplete 25
+
+$ExcelPlatformIssues = Get-ExcelPlatformIssues -ExcelFile $CoreFile
+
+Write-Progress -Id 1 -activity "Processing Office Apps" -Status "30% Complete." -PercentComplete 30
+
+$ExcelSupportTickets = Get-ExcelSupportTicket -ExcelFile $CoreFile
+
+Write-Progress -Id 1 -activity "Processing Office Apps" -Status "35% Complete." -PercentComplete 35
+
+$ExcelWorkloadInventory = Get-ExcelWorkloadInventory -ExcelFile $CoreFile
+
+Write-Progress -Id 1 -activity "Processing Office Apps" -Status "40% Complete." -PercentComplete 40
+
+$ExcelRetirements = Get-ExcelRetirement -ExcelFile $CoreFile
+
+Write-Progress -Id 1 -activity "Processing Office Apps" -Status "45% Complete." -PercentComplete 45
+
+
+$PPTFinalFile = New-PPTFile -PPTTemplateFile $pptTemplateFilePath  # NEED FIX: PPTTemplateFile parameter does not use in the function
+Write-Host "PowerPoint" -ForegroundColor DarkRed -NoNewline
+Write-Host " and " -NoNewline
+Write-Host "Excel" -ForegroundColor DarkGreen -NoNewline
+Write-Host " "
+Write-Host "Editing " -NoNewline
+$NewAssessmentFindingsFile = New-AssessmentFindingsFile -AssessmentFindingsFile $assessmentFindingsFilePath
+
+
+$AUTOMESSAGE = 'AUTOMATICALLY MODIFIED (Please Review)'
+
+Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Getting Resource Types..')
+
+$TempImpactedResources = $ExcelImpactedResources | Select-Object -Property 'Resource Type', 'id' -Unique
+
+$ResourcesTypes = $TempImpactedResources | Group-Object -Property 'Resource Type' | Sort-Object -Property 'Count' -Descending | Select-Object -First 10
+
+Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting to Process Assessment Findings..')
+
+$ImpactedResourcesFormatted = Initialize-ExcelImpactedResources -ImpactedResources $ExcelImpactedResources
+Export-ExcelImpactedResources -ImpactedResourcesFormatted $ImpactedResourcesFormatted
+
+$RecommendationsFormatted = Initialize-ExcelRecommendations -ImpactedResources $ExcelImpactedResources
+Export-ExcelRecommendations -RecommendationsFormatted $RecommendationsFormatted
+
+Export-ExcelWorkloadInventory -ExcelWorkloadInventory $ExcelWorkloadInventory
+
+$ExcelFileLive = Build-ExcelPivotTable -NewAssessmentFindingsFile $NewAssessmentFindingsFile
+
+Build-ExcelPivotChart -Excel $ExcelFileLive
 
 try {
-    # Start the stopwatch to time the script
-    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
-
-    #Call the functions
-    $Version = "2.1.5"
-    Write-Host "Version: " -NoNewline
-    Write-Host $Version -ForegroundColor DarkBlue -NoNewline
-    Write-Host " "
-
-    # Checking the operating system running this script.
-    if (-not $IsWindows) {
-        Write-Error -Message 'This script only supports Windows operating systems currently. Please try to run with Windows operating systems.'
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting PowerPoint..')
+    # Openning PPT
+    try
+    {
+        $Application = New-Object -ComObject PowerPoint.Application
+        $Presentation = $Application.Presentations.Open($pptTemplateFilePath, $null, $null, $null)
+    }
+    catch
+    {
+        Write-Host ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + "- Error: " + $_.Exception.Message)
+        Get-Process -Name "POWERPNT" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
     }
 
-    # Check if Clipboard History is enabled
-    $clipboardHistory = Get-ItemProperty -Path 'HKCU:\Software\Microsoft\Clipboard' -Name 'EnableClipboardHistory' -ErrorAction SilentlyContinue
-
-    if ($clipboardHistory.EnableClipboardHistory -eq 1) {
-        Write-Error -Message 'Clipboard History is enabled. Please disable Clipboard History before running this script.'
-    } else {
-        Write-Debug 'Clipboard History is disabled.'
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting Excel..')
+    # Openning Excel
+    try
+    {
+        $ExcelApplication = New-Object -ComObject Excel.Application
+        Start-Sleep -Milliseconds 500
+        $ExcelWorkbooks = $ExcelApplication.Workbooks.Open($NewAssessmentFindingsFile)
     }
-
-    # TODO: Remove if not needed
-    <# $CurrentPath = Get-Location
-    $CurrentPath = $CurrentPath.Path #>
-    if ($PSBoundParameters.ContainsKey('PPTTemplateFile')) {
-        # Resolve-Path throw exception if the path does not exist.
-        $pptTemplateFilePath = (Resolve-Path -LiteralPath $PPTTemplateFile).Path
-        if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
-            # The specified path is not a file, it may be a folder.
-            Write-Error -Message ('The specified PowerPoint template file "{0}" is not a file. Please provide the path to the PowerPoint template file.' -f $pptTemplateFilePath)
-        }
-    }
-    else {
-        $pptTemplateFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'Mandatory - Executive Summary presentation - Template.pptx'
-        if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
-            Write-Error -Message ('The default PowerPoint template file "{0}" does not exist. Please contact the WARA team via GitHub or Microsoft Teams.' -f $pptTemplateFilePath)
-        }
-    }
-    Write-Host ('PowerPoint Template File: {0}' -f $pptTemplateFilePath)
-
-    if (!$AssessmentFindingsFile) {
-        write-host ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx")
-        if ((Test-Path -Path ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx") -PathType Leaf) -eq $true) {
-            $AssessmentFindingsFile = ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx")
-        }
-        else {
-            Write-Error 'Assessment Findings file is missing. Please provide the path to the Assessment Findings file.'
-        }
-    }
-
-    if (!$ExpertAnalysisFile) {
-        Write-Error 'The Expert-Analysis Excel file is missing. Please provide the path to the Expert-Analysis Excel file.'
+    catch
+    {
+        Write-Host ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + "- Error: " + $_.Exception.Message)
+        Get-Process -Name "excel" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
     }
 
 
-    if (!$CustomerName) {
-        $CustomerName = '[Customer Name]'
+    Remove-PPTSlide1 -Presentation $Presentation -CustomerName $CustomerName -WorkloadName $WorkloadName
+    Build-PPTSlide12 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -WorkloadName $WorkloadName -ResourcesType $ResourcesTypes
+    Build-PPTSlide16 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
+
+    while ([string]::IsNullOrEmpty($ExcelWorkbooks)) {
+        Start-Sleep 1
     }
 
-    if (!$WorkloadName) {
-        $WorkloadName = '[Workload Name]'
-    }
+    Build-PPTSlide17 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ExcelWorkbooks $ExcelWorkbooks
 
-    $TableStyle = 'Light19'
+    Build-PPTSlide30 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -Retirements $ExcelRetirements
 
-    $CoreFile = get-item -Path $ExpertAnalysisFile
-    $CoreFile = $CoreFile.FullName
+    Build-PPTSlide29 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -SupportTickets $ExcelSupportTickets
 
-    Test-ReviewedRecommendations -ExcelFile $CoreFile
+    Build-PPTSlide28 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -PlatformIssues $ExcelPlatformIssues
 
-    Write-Debug (' ---------------------------------- STARTING REPORT GENERATOR SCRIPT --------------------------------------- ')
-    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting Report Generator Script..')
-    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Script Version: ' + $Version)
-    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Excel File: ' + $ExpertAnalysisFile)
-    $ImportExcel = Get-Module -Name ImportExcel -ListAvailable -ErrorAction silentlycontinue
-    foreach ($IExcel in $ImportExcel) {
-        $IExcelPath = $IExcel.Path
-        $IExcelVer = [string]$IExcel.Version
-        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - ImportExcel Module Path: ' + $IExcelPath)
-        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - ImportExcel Module Version: ' + $IExcelVer)
-    }
+    Build-PPTSlide25 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
+    Build-PPTSlide24 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
+    Build-PPTSlide23 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
 
-    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "10% Complete." -PercentComplete 10
-    Test-Requirement
-    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "15% Complete." -PercentComplete 15
-    #Set-LocalFile
-    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "20% Complete." -PercentComplete 20
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Closing Excel..')
+    $ExcelWorkbooks.Save()
+    $ExcelWorkbooks.Close()
+    $ExcelApplication.Quit()
 
-    $ExcelImpactedResources = Get-ExcelImpactedResources -ExcelFile $CoreFile
-
-    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "25% Complete." -PercentComplete 25
-
-    $ExcelPlatformIssues = Get-ExcelPlatformIssues -ExcelFile $CoreFile
-
-    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "30% Complete." -PercentComplete 30
-
-    $ExcelSupportTickets = Get-ExcelSupportTicket -ExcelFile $CoreFile
-
-    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "35% Complete." -PercentComplete 35
-
-    $ExcelWorkloadInventory = Get-ExcelWorkloadInventory -ExcelFile $CoreFile
-
-    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "40% Complete." -PercentComplete 40
-
-    $ExcelRetirements = Get-ExcelRetirement -ExcelFile $CoreFile
-
-    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "45% Complete." -PercentComplete 45
-
-
-    $PPTFinalFile = New-PPTFile -PPTTemplateFile $pptTemplateFilePath  # NEED FIX: PPTTemplateFile parameter does not use in the function
-    Write-Host "PowerPoint" -ForegroundColor DarkRed -NoNewline
-    Write-Host " and " -NoNewline
-    Write-Host "Excel" -ForegroundColor DarkGreen -NoNewline
-    Write-Host " "
-    Write-Host "Editing " -NoNewline
-    $NewAssessmentFindingsFile = New-AssessmentFindingsFile -AssessmentFindingsFile $AssessmentFindingsFile
-
-
-    $AUTOMESSAGE = 'AUTOMATICALLY MODIFIED (Please Review)'
-
-    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Getting Resource Types..')
-
-    $TempImpactedResources = $ExcelImpactedResources | Select-Object -Property 'Resource Type', 'id' -Unique
-
-    $ResourcesTypes = $TempImpactedResources | Group-Object -Property 'Resource Type' | Sort-Object -Property 'Count' -Descending | Select-Object -First 10
-
-    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting to Process Assessment Findings..')
-
-    $ImpactedResourcesFormatted = Initialize-ExcelImpactedResources -ImpactedResources $ExcelImpactedResources
-    Export-ExcelImpactedResources -ImpactedResourcesFormatted $ImpactedResourcesFormatted
-
-    $RecommendationsFormatted = Initialize-ExcelRecommendations -ImpactedResources $ExcelImpactedResources
-    Export-ExcelRecommendations -RecommendationsFormatted $RecommendationsFormatted
-
-    Export-ExcelWorkloadInventory -ExcelWorkloadInventory $ExcelWorkloadInventory
-
-    $ExcelFileLive = Build-ExcelPivotTable -NewAssessmentFindingsFile $NewAssessmentFindingsFile
-
-    Build-ExcelPivotChart -Excel $ExcelFileLive
-
-    try {
-        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting PowerPoint..')
-        # Openning PPT
-        try
-        {
-            $Application = New-Object -ComObject PowerPoint.Application
-            $Presentation = $Application.Presentations.Open($pptTemplateFilePath, $null, $null, $null)
-        }
-        catch
-        {
-            Write-Host ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + "- Error: " + $_.Exception.Message)
-            Get-Process -Name "POWERPNT" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
-        }
-
-        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting Excel..')
-        # Openning Excel
-        try
-        {
-            $ExcelApplication = New-Object -ComObject Excel.Application
-            Start-Sleep -Milliseconds 500
-            $ExcelWorkbooks = $ExcelApplication.Workbooks.Open($NewAssessmentFindingsFile)
-        }
-        catch
-        {
-            Write-Host ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + "- Error: " + $_.Exception.Message)
-            Get-Process -Name "excel" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
-        }
-
-
-        Remove-PPTSlide1 -Presentation $Presentation -CustomerName $CustomerName -WorkloadName $WorkloadName
-        Build-PPTSlide12 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -WorkloadName $WorkloadName -ResourcesType $ResourcesTypes
-        Build-PPTSlide16 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
-
-        while ([string]::IsNullOrEmpty($ExcelWorkbooks)) {
-            Start-Sleep 1
-        }
-
-        Build-PPTSlide17 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ExcelWorkbooks $ExcelWorkbooks
-
-        Build-PPTSlide30 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -Retirements $ExcelRetirements
-
-        Build-PPTSlide29 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -SupportTickets $ExcelSupportTickets
-
-        Build-PPTSlide28 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -PlatformIssues $ExcelPlatformIssues
-
-        Build-PPTSlide25 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
-        Build-PPTSlide24 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
-        Build-PPTSlide23 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
-
-        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Closing Excel..')
-        $ExcelWorkbooks.Save()
-        $ExcelWorkbooks.Close()
-        $ExcelApplication.Quit()
-
-        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Closing PowerPoint..')
-        $Presentation.SaveAs($PPTFinalFile)
-        $Presentation.Close()
-        $Application.Quit()
-
-        #if ($csvExport.IsPresent) {
-        $WorkloadRecommendationTemplate = Build-SummaryActionPlan -ImpactedResources $ExcelImpactedResources -includeLow $includeLow
-
-        $CSVFile = ("$PWD\Impacted Resources and Recommendations Template " + (get-date -Format "yyyy-MM-dd-HH-mm") + '.csv')
-
-        $WorkloadRecommendationTemplate | Export-Csv -Path $CSVFile
-        #}
-    }
-    finally {
-        if (Get-Process -Name "POWERPNT" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' })
-        {
-            Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Trying to kill PowerPoint process.')
-            Get-Process -Name "POWERPNT" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
-        }
-
-        if (Get-Process -Name "excel" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } )
-        {
-            Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Trying to kill Excel process.')
-            Get-Process -Name "excel" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
-        }
-    }
-
-    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "90% Complete." -PercentComplete 90
-
-    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "100% Complete." -Completed
-
-    $stopwatch.Stop()
-
-    ################ Finishing
-
-    Write-Host "---------------------------------------------------------------------"
-    Write-Host ('Execution Complete. Total Runtime was: ') -NoNewline
-    Write-Host $stopwatch.Elapsed.toString('hh\:mm\:ss') -ForegroundColor Cyan
-    Write-Host 'PowerPoint File Saved as: ' -NoNewline
-    Write-Host $PPTFinalFile -ForegroundColor Cyan
-    Write-Host 'Assessment Findings File Saved as: ' -NoNewline
-    Write-Host $NewAssessmentFindingsFile -ForegroundColor Cyan
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Closing PowerPoint..')
+    $Presentation.SaveAs($PPTFinalFile)
+    $Presentation.Close()
+    $Application.Quit()
 
     #if ($csvExport.IsPresent) {
-    Write-Host 'CSV File Saved as: ' -NoNewline
-    Write-Host $CSVFile -ForegroundColor Cyan
-    #}
+    $WorkloadRecommendationTemplate = Build-SummaryActionPlan -ImpactedResources $ExcelImpactedResources -includeLow $includeLow
 
-    Write-Host "---------------------------------------------------------------------"
+    $CSVFile = ("$PWD\Impacted Resources and Recommendations Template " + (get-date -Format "yyyy-MM-dd-HH-mm") + '.csv')
+
+    $WorkloadRecommendationTemplate | Export-Csv -Path $CSVFile
+    #}
 }
-catch {
-    $exceptionMessage = New-ExceptionMessage -ErrorRecord $_
-    $exceptionMessage | Write-Host -ForegroundColor Yellow
+finally {
+    if (Get-Process -Name "POWERPNT" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' })
+    {
+        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Trying to kill PowerPoint process.')
+        Get-Process -Name "POWERPNT" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
+    }
+
+    if (Get-Process -Name "excel" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } )
+    {
+        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Trying to kill Excel process.')
+        Get-Process -Name "excel" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
+    }
 }
+
+Write-Progress -Id 1 -activity "Processing Office Apps" -Status "90% Complete." -PercentComplete 90
+
+Write-Progress -Id 1 -activity "Processing Office Apps" -Status "100% Complete." -Completed
+
+$stopwatch.Stop()
+
+################ Finishing
+
+Write-Host "---------------------------------------------------------------------"
+Write-Host ('Execution Complete. Total Runtime was: ') -NoNewline
+Write-Host $stopwatch.Elapsed.toString('hh\:mm\:ss') -ForegroundColor Cyan
+Write-Host 'PowerPoint File Saved as: ' -NoNewline
+Write-Host $PPTFinalFile -ForegroundColor Cyan
+Write-Host 'Assessment Findings File Saved as: ' -NoNewline
+Write-Host $NewAssessmentFindingsFile -ForegroundColor Cyan
+
+#if ($csvExport.IsPresent) {
+Write-Host 'CSV File Saved as: ' -NoNewline
+Write-Host $CSVFile -ForegroundColor Cyan
+#}
+
+Write-Host "---------------------------------------------------------------------"

--- a/src/modules/wara/reports/3_wara_reports_generator.ps1
+++ b/src/modules/wara/reports/3_wara_reports_generator.ps1
@@ -1287,17 +1287,16 @@ try {
 
     # Checking the operating system running this script.
     if (-not $IsWindows) {
-        Write-Host 'This script only supports Windows operating systems currently. Please try to run with Windows operating systems.'
-        Exit
+        Write-Error -Message 'This script only supports Windows operating systems currently. Please try to run with Windows operating systems.'
     }
 
     # Check if Clipboard History is enabled
-    $clipboardHistory = Get-ItemProperty -Path "HKCU:\Software\Microsoft\Clipboard" -Name "EnableClipboardHistory" -ErrorAction SilentlyContinue
+    $clipboardHistory = Get-ItemProperty -Path 'HKCU:\Software\Microsoft\Clipboard' -Name 'EnableClipboardHistory' -ErrorAction SilentlyContinue
 
     if ($clipboardHistory.EnableClipboardHistory -eq 1) {
-        Throw "Clipboard History is enabled. Please disable Clipboard History before running this script."
+        Write-Error -Message 'Clipboard History is enabled. Please disable Clipboard History before running this script.'
     } else {
-        Write-Debug "Clipboard History is disabled."
+        Write-Debug 'Clipboard History is disabled.'
     }
 
     # TODO: Remove if not needed
@@ -1309,14 +1308,12 @@ try {
         if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
             # The specified path is not a file, it may be a folder.
             Write-Error -Message ('The specified PowerPoint template file "{0}" is not a file. Please provide the path to the PowerPoint template file.' -f $pptTemplateFilePath)
-            Exit  # TODO: This can be deleted after adding exception handling.
         }
     }
     else {
         $pptTemplateFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'Mandatory - Executive Summary presentation - Template.pptx'
         if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
-            Write-Error -Message ('The default PowerPoint template file "{0}" does not exist. Please contact the WARA team via GitHub or Microsoft Teams.' -f $pptTemplateFilePath)  # TODO
-            Exit  # TODO: This can be deleted after adding exception handling.
+            Write-Error -Message ('The default PowerPoint template file "{0}" does not exist. Please contact the WARA team via GitHub or Microsoft Teams.' -f $pptTemplateFilePath)
         }
     }
     Write-Host ('PowerPoint Template File: {0}' -f $pptTemplateFilePath)
@@ -1327,14 +1324,12 @@ try {
             $AssessmentFindingsFile = ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx")
         }
         else {
-            Write-Error "Assessment Findings file is missing. Please provide the path to the Assessment Findings file."
-            Exit
+            Write-Error 'Assessment Findings file is missing. Please provide the path to the Assessment Findings file.'
         }
     }
 
     if (!$ExpertAnalysisFile) {
-        Write-Host "The Expert-Analysis Excel file is missing. Please provide the path to the Expert-Analysis Excel file." -ForegroundColor Yellow
-        Exit
+        Write-Error 'The Expert-Analysis Excel file is missing. Please provide the path to the Expert-Analysis Excel file.'
     }
 
 

--- a/src/modules/wara/reports/3_wara_reports_generator.ps1
+++ b/src/modules/wara/reports/3_wara_reports_generator.ps1
@@ -49,9 +49,11 @@ Param(
   [Alias('ExcelFile')]
   [string] $ExpertAnalysisFile,
 
-  [string] $AssessmentFindingsFile,
+  [Parameter(Mandatory = $false)]
+  [string] $AssessmentFindingsFile = (Join-Path -Path $PSScriptRoot -ChildPath 'Assessment-Findings-Report-v1.xlsx'),
 
-  [string] $PPTTemplateFile
+  [Parameter(Mandatory = $false)]
+  [string] $PPTTemplateFile = (Join-Path -Path $PSScriptRoot -ChildPath 'Mandatory - Executive Summary presentation - Template.pptx')
 )
 
 $ErrorActionPreference = 'Stop'
@@ -117,34 +119,16 @@ if ($clipboardHistory.EnableClipboardHistory -eq 1) {
 }
 
 # Verify the PPTTemplateFile parameter
-if ($PSBoundParameters.ContainsKey('PPTTemplateFile')) {
-    # Resolve-Path throw exception if the path does not exist.
-    $pptTemplateFilePath = (Resolve-Path -LiteralPath $PPTTemplateFile).Path
-    if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
-        throw 'The specified PowerPoint template file "{0}" is not a file. Please provide the path to the PowerPoint template file.' -f $pptTemplateFilePath
-    }
-}
-else {
-    $pptTemplateFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'Mandatory - Executive Summary presentation - Template.pptx'
-    if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
-        throw 'The default PowerPoint template file "{0}" does not exist. Please contact the WARA team via https://aka.ms/waratools/issue or Microsoft Teams.' -f $pptTemplateFilePath
-    }
+$pptTemplateFilePath = (Resolve-Path -LiteralPath $PPTTemplateFile).Path
+if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
+    throw 'The specified PowerPoint template file "{0}" is not a file. Please provide the path to the PowerPoint template file.' -f $pptTemplateFilePath
 }
 Write-Host ('PowerPoint Template File: {0}' -f $pptTemplateFilePath)
 
 # Verify the AssessmentFindingsFile parameter
-if ($PSBoundParameters.ContainsKey('AssessmentFindingsFile')) {
-    # Resolve-Path throw exception if the path does not exist.
-    $assessmentFindingsFilePath = (Resolve-Path -LiteralPath $AssessmentFindingsFile).Path
-    if (-not (Test-Path -PathType Leaf -LiteralPath $assessmentFindingsFilePath)) {
-        throw 'The specified Assessment Findings file "{0}" is not a file. Please provide the path to the Assessment Findings file.' -f $assessmentFindingsFilePath
-    }
-}
-else {
-    $assessmentFindingsFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'Assessment-Findings-Report-v1.xlsx'
-    if (-not (Test-Path -PathType Leaf -LiteralPath $assessmentFindingsFilePath)) {
-        throw 'The default Assessment Findings file "{0}" does not exist. Please contact the WARA team via https://aka.ms/waratools/issue or Microsoft Teams.' -f $assessmentFindingsFilePath
-    }
+$assessmentFindingsFilePath = (Resolve-Path -LiteralPath $AssessmentFindingsFile).Path
+if (-not (Test-Path -PathType Leaf -LiteralPath $assessmentFindingsFilePath)) {
+    throw 'The specified Assessment Findings file "{0}" is not a file. Please provide the path to the Assessment Findings file.' -f $assessmentFindingsFilePath
 }
 Write-Host ('Assessment Findings File: {0}' -f $assessmentFindingsFilePath)
 

--- a/src/modules/wara/reports/3_wara_reports_generator.ps1
+++ b/src/modules/wara/reports/3_wara_reports_generator.ps1
@@ -1275,250 +1275,256 @@ function New-ExceptionMessage {
 
 ######################## Main Script Part ##########################
 
-# Start the stopwatch to time the script
-$stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+try {
+    # Start the stopwatch to time the script
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-#Call the functions
-$Version = "2.1.5"
-Write-Host "Version: " -NoNewline
-Write-Host $Version -ForegroundColor DarkBlue -NoNewline
-Write-Host " "
+    #Call the functions
+    $Version = "2.1.5"
+    Write-Host "Version: " -NoNewline
+    Write-Host $Version -ForegroundColor DarkBlue -NoNewline
+    Write-Host " "
 
-# Checking the operating system running this script.
-if (-not $IsWindows) {
-  Write-Host 'This script only supports Windows operating systems currently. Please try to run with Windows operating systems.'
-  Exit
-  }
-
-  # Check if Clipboard History is enabled
-$clipboardHistory = Get-ItemProperty -Path "HKCU:\Software\Microsoft\Clipboard" -Name "EnableClipboardHistory" -ErrorAction SilentlyContinue
-
-if ($clipboardHistory.EnableClipboardHistory -eq 1) {
-    Throw "Clipboard History is enabled. Please disable Clipboard History before running this script."
-} else {
-    Write-Debug "Clipboard History is disabled."
-}
-
-# TODO: Remove if not needed
-<# $CurrentPath = Get-Location
-$CurrentPath = $CurrentPath.Path #>
-if ($PSBoundParameters.ContainsKey('PPTTemplateFile')) {
-    # Resolve-Path throw exception if the path does not exist.
-    $pptTemplateFilePath = (Resolve-Path -LiteralPath $PPTTemplateFile).Path
-    if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
-        # The specified path is not a file, it may be a folder.
-        Write-Error -Message ('The specified PowerPoint template file "{0}" is not a file. Please provide the path to the PowerPoint template file.' -f $pptTemplateFilePath)
-        Exit  # TODO: This can be deleted after adding exception handling.
+    # Checking the operating system running this script.
+    if (-not $IsWindows) {
+        Write-Host 'This script only supports Windows operating systems currently. Please try to run with Windows operating systems.'
+        Exit
     }
-}
-else {
-    $pptTemplateFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'Mandatory - Executive Summary presentation - Template.pptx'
-    if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
-        Write-Error -Message ('The default PowerPoint template file "{0}" does not exist. Please contact the WARA team via GitHub or Microsoft Teams.' -f $pptTemplateFilePath)  # TODO
-        Exit  # TODO: This can be deleted after adding exception handling.
+
+    # Check if Clipboard History is enabled
+    $clipboardHistory = Get-ItemProperty -Path "HKCU:\Software\Microsoft\Clipboard" -Name "EnableClipboardHistory" -ErrorAction SilentlyContinue
+
+    if ($clipboardHistory.EnableClipboardHistory -eq 1) {
+        Throw "Clipboard History is enabled. Please disable Clipboard History before running this script."
+    } else {
+        Write-Debug "Clipboard History is disabled."
     }
-}
-Write-Host ('PowerPoint Template File: {0}' -f $pptTemplateFilePath)
 
-if (!$AssessmentFindingsFile) {
-  write-host ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx")
-  if ((Test-Path -Path ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx") -PathType Leaf) -eq $true) {
-    $AssessmentFindingsFile = ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx")
-  }
-  else {
-    Write-Error "Assessment Findings file is missing. Please provide the path to the Assessment Findings file."
-    Exit
-  }
-}
+    # TODO: Remove if not needed
+    <# $CurrentPath = Get-Location
+    $CurrentPath = $CurrentPath.Path #>
+    if ($PSBoundParameters.ContainsKey('PPTTemplateFile')) {
+        # Resolve-Path throw exception if the path does not exist.
+        $pptTemplateFilePath = (Resolve-Path -LiteralPath $PPTTemplateFile).Path
+        if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
+            # The specified path is not a file, it may be a folder.
+            Write-Error -Message ('The specified PowerPoint template file "{0}" is not a file. Please provide the path to the PowerPoint template file.' -f $pptTemplateFilePath)
+            Exit  # TODO: This can be deleted after adding exception handling.
+        }
+    }
+    else {
+        $pptTemplateFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'Mandatory - Executive Summary presentation - Template.pptx'
+        if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
+            Write-Error -Message ('The default PowerPoint template file "{0}" does not exist. Please contact the WARA team via GitHub or Microsoft Teams.' -f $pptTemplateFilePath)  # TODO
+            Exit  # TODO: This can be deleted after adding exception handling.
+        }
+    }
+    Write-Host ('PowerPoint Template File: {0}' -f $pptTemplateFilePath)
 
-if (!$ExpertAnalysisFile) {
-  Write-Host "The Expert-Analysis Excel file is missing. Please provide the path to the Expert-Analysis Excel file." -ForegroundColor Yellow
-  Exit
-}
+    if (!$AssessmentFindingsFile) {
+        write-host ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx")
+        if ((Test-Path -Path ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx") -PathType Leaf) -eq $true) {
+            $AssessmentFindingsFile = ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx")
+        }
+        else {
+            Write-Error "Assessment Findings file is missing. Please provide the path to the Assessment Findings file."
+            Exit
+        }
+    }
 
-
-if (!$CustomerName) {
-  $CustomerName = '[Customer Name]'
-}
-
-if (!$WorkloadName) {
-  $WorkloadName = '[Workload Name]'
-}
-
-$TableStyle = 'Light19'
-
-$CoreFile = get-item -Path $ExpertAnalysisFile
-$CoreFile = $CoreFile.FullName
-
-Test-ReviewedRecommendations -ExcelFile $CoreFile
-
-Write-Debug (' ---------------------------------- STARTING REPORT GENERATOR SCRIPT --------------------------------------- ')
-Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting Report Generator Script..')
-Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Script Version: ' + $Version)
-Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Excel File: ' + $ExpertAnalysisFile)
-$ImportExcel = Get-Module -Name ImportExcel -ListAvailable -ErrorAction silentlycontinue
-foreach ($IExcel in $ImportExcel) {
-    $IExcelPath = $IExcel.Path
-    $IExcelVer = [string]$IExcel.Version
-    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - ImportExcel Module Path: ' + $IExcelPath)
-    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - ImportExcel Module Version: ' + $IExcelVer)
-}
-
-Write-Progress -Id 1 -activity "Processing Office Apps" -Status "10% Complete." -PercentComplete 10
-Test-Requirement
-Write-Progress -Id 1 -activity "Processing Office Apps" -Status "15% Complete." -PercentComplete 15
-#Set-LocalFile
-Write-Progress -Id 1 -activity "Processing Office Apps" -Status "20% Complete." -PercentComplete 20
-
-$ExcelImpactedResources = Get-ExcelImpactedResources -ExcelFile $CoreFile
-
-Write-Progress -Id 1 -activity "Processing Office Apps" -Status "25% Complete." -PercentComplete 25
-
-$ExcelPlatformIssues = Get-ExcelPlatformIssues -ExcelFile $CoreFile
-
-Write-Progress -Id 1 -activity "Processing Office Apps" -Status "30% Complete." -PercentComplete 30
-
-$ExcelSupportTickets = Get-ExcelSupportTicket -ExcelFile $CoreFile
-
-Write-Progress -Id 1 -activity "Processing Office Apps" -Status "35% Complete." -PercentComplete 35
-
-$ExcelWorkloadInventory = Get-ExcelWorkloadInventory -ExcelFile $CoreFile
-
-Write-Progress -Id 1 -activity "Processing Office Apps" -Status "40% Complete." -PercentComplete 40
-
-$ExcelRetirements = Get-ExcelRetirement -ExcelFile $CoreFile
-
-Write-Progress -Id 1 -activity "Processing Office Apps" -Status "45% Complete." -PercentComplete 45
+    if (!$ExpertAnalysisFile) {
+        Write-Host "The Expert-Analysis Excel file is missing. Please provide the path to the Expert-Analysis Excel file." -ForegroundColor Yellow
+        Exit
+    }
 
 
-$PPTFinalFile = New-PPTFile -PPTTemplateFile $pptTemplateFilePath  # NEED FIX: PPTTemplateFile parameter does not use in the function
-Write-Host "PowerPoint" -ForegroundColor DarkRed -NoNewline
-Write-Host " and " -NoNewline
-Write-Host "Excel" -ForegroundColor DarkGreen -NoNewline
-Write-Host " "
-Write-Host "Editing " -NoNewline
-$NewAssessmentFindingsFile = New-AssessmentFindingsFile -AssessmentFindingsFile $AssessmentFindingsFile
+    if (!$CustomerName) {
+        $CustomerName = '[Customer Name]'
+    }
+
+    if (!$WorkloadName) {
+        $WorkloadName = '[Workload Name]'
+    }
+
+    $TableStyle = 'Light19'
+
+    $CoreFile = get-item -Path $ExpertAnalysisFile
+    $CoreFile = $CoreFile.FullName
+
+    Test-ReviewedRecommendations -ExcelFile $CoreFile
+
+    Write-Debug (' ---------------------------------- STARTING REPORT GENERATOR SCRIPT --------------------------------------- ')
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting Report Generator Script..')
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Script Version: ' + $Version)
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Excel File: ' + $ExpertAnalysisFile)
+    $ImportExcel = Get-Module -Name ImportExcel -ListAvailable -ErrorAction silentlycontinue
+    foreach ($IExcel in $ImportExcel) {
+        $IExcelPath = $IExcel.Path
+        $IExcelVer = [string]$IExcel.Version
+        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - ImportExcel Module Path: ' + $IExcelPath)
+        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - ImportExcel Module Version: ' + $IExcelVer)
+    }
+
+    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "10% Complete." -PercentComplete 10
+    Test-Requirement
+    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "15% Complete." -PercentComplete 15
+    #Set-LocalFile
+    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "20% Complete." -PercentComplete 20
+
+    $ExcelImpactedResources = Get-ExcelImpactedResources -ExcelFile $CoreFile
+
+    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "25% Complete." -PercentComplete 25
+
+    $ExcelPlatformIssues = Get-ExcelPlatformIssues -ExcelFile $CoreFile
+
+    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "30% Complete." -PercentComplete 30
+
+    $ExcelSupportTickets = Get-ExcelSupportTicket -ExcelFile $CoreFile
+
+    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "35% Complete." -PercentComplete 35
+
+    $ExcelWorkloadInventory = Get-ExcelWorkloadInventory -ExcelFile $CoreFile
+
+    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "40% Complete." -PercentComplete 40
+
+    $ExcelRetirements = Get-ExcelRetirement -ExcelFile $CoreFile
+
+    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "45% Complete." -PercentComplete 45
 
 
-$AUTOMESSAGE = 'AUTOMATICALLY MODIFIED (Please Review)'
+    $PPTFinalFile = New-PPTFile -PPTTemplateFile $pptTemplateFilePath  # NEED FIX: PPTTemplateFile parameter does not use in the function
+    Write-Host "PowerPoint" -ForegroundColor DarkRed -NoNewline
+    Write-Host " and " -NoNewline
+    Write-Host "Excel" -ForegroundColor DarkGreen -NoNewline
+    Write-Host " "
+    Write-Host "Editing " -NoNewline
+    $NewAssessmentFindingsFile = New-AssessmentFindingsFile -AssessmentFindingsFile $AssessmentFindingsFile
 
-Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Getting Resource Types..')
 
-$TempImpactedResources = $ExcelImpactedResources | Select-Object -Property 'Resource Type', 'id' -Unique
+    $AUTOMESSAGE = 'AUTOMATICALLY MODIFIED (Please Review)'
 
-$ResourcesTypes = $TempImpactedResources | Group-Object -Property 'Resource Type' | Sort-Object -Property 'Count' -Descending | Select-Object -First 10
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Getting Resource Types..')
 
-Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting to Process Assessment Findings..')
+    $TempImpactedResources = $ExcelImpactedResources | Select-Object -Property 'Resource Type', 'id' -Unique
 
-$ImpactedResourcesFormatted = Initialize-ExcelImpactedResources -ImpactedResources $ExcelImpactedResources
-Export-ExcelImpactedResources -ImpactedResourcesFormatted $ImpactedResourcesFormatted
+    $ResourcesTypes = $TempImpactedResources | Group-Object -Property 'Resource Type' | Sort-Object -Property 'Count' -Descending | Select-Object -First 10
 
-$RecommendationsFormatted = Initialize-ExcelRecommendations -ImpactedResources $ExcelImpactedResources
-Export-ExcelRecommendations -RecommendationsFormatted $RecommendationsFormatted
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting to Process Assessment Findings..')
 
-Export-ExcelWorkloadInventory -ExcelWorkloadInventory $ExcelWorkloadInventory
+    $ImpactedResourcesFormatted = Initialize-ExcelImpactedResources -ImpactedResources $ExcelImpactedResources
+    Export-ExcelImpactedResources -ImpactedResourcesFormatted $ImpactedResourcesFormatted
 
-$ExcelFileLive = Build-ExcelPivotTable -NewAssessmentFindingsFile $NewAssessmentFindingsFile
+    $RecommendationsFormatted = Initialize-ExcelRecommendations -ImpactedResources $ExcelImpactedResources
+    Export-ExcelRecommendations -RecommendationsFormatted $RecommendationsFormatted
 
-Build-ExcelPivotChart -Excel $ExcelFileLive
+    Export-ExcelWorkloadInventory -ExcelWorkloadInventory $ExcelWorkloadInventory
 
-Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting PowerPoint..')
-# Openning PPT
-try
+    $ExcelFileLive = Build-ExcelPivotTable -NewAssessmentFindingsFile $NewAssessmentFindingsFile
+
+    Build-ExcelPivotChart -Excel $ExcelFileLive
+
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting PowerPoint..')
+    # Openning PPT
+    try
     {
         $Application = New-Object -ComObject PowerPoint.Application
         $Presentation = $Application.Presentations.Open($pptTemplateFilePath, $null, $null, $null)
     }
-catch
+    catch
     {
         Write-Host ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + "- Error: " + $_.Exception.Message)
         Get-Process -Name "POWERPNT" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
     }
 
-Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting Excel..')
-# Openning Excel
-try
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting Excel..')
+    # Openning Excel
+    try
     {
         $ExcelApplication = New-Object -ComObject Excel.Application
         Start-Sleep -Milliseconds 500
         $ExcelWorkbooks = $ExcelApplication.Workbooks.Open($NewAssessmentFindingsFile)
     }
-catch
+    catch
     {
         Write-Host ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + "- Error: " + $_.Exception.Message)
         Get-Process -Name "excel" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
     }
 
 
-Remove-PPTSlide1 -Presentation $Presentation -CustomerName $CustomerName -WorkloadName $WorkloadName
-Build-PPTSlide12 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -WorkloadName $WorkloadName -ResourcesType $ResourcesTypes
-Build-PPTSlide16 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
+    Remove-PPTSlide1 -Presentation $Presentation -CustomerName $CustomerName -WorkloadName $WorkloadName
+    Build-PPTSlide12 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -WorkloadName $WorkloadName -ResourcesType $ResourcesTypes
+    Build-PPTSlide16 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
 
-while ([string]::IsNullOrEmpty($ExcelWorkbooks)) {
-    Start-Sleep 1
-}
+    while ([string]::IsNullOrEmpty($ExcelWorkbooks)) {
+        Start-Sleep 1
+    }
 
-Build-PPTSlide17 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ExcelWorkbooks $ExcelWorkbooks
+    Build-PPTSlide17 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ExcelWorkbooks $ExcelWorkbooks
 
-Build-PPTSlide30 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -Retirements $ExcelRetirements
+    Build-PPTSlide30 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -Retirements $ExcelRetirements
 
-Build-PPTSlide29 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -SupportTickets $ExcelSupportTickets
+    Build-PPTSlide29 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -SupportTickets $ExcelSupportTickets
 
-Build-PPTSlide28 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -PlatformIssues $ExcelPlatformIssues
+    Build-PPTSlide28 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -PlatformIssues $ExcelPlatformIssues
 
-Build-PPTSlide25 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
-Build-PPTSlide24 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
-Build-PPTSlide23 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
+    Build-PPTSlide25 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
+    Build-PPTSlide24 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
+    Build-PPTSlide23 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -ImpactedResources $ExcelImpactedResources
 
-Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Closing Excel..')
-$ExcelWorkbooks.Save()
-$ExcelWorkbooks.Close()
-$ExcelApplication.Quit()
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Closing Excel..')
+    $ExcelWorkbooks.Save()
+    $ExcelWorkbooks.Close()
+    $ExcelApplication.Quit()
 
-Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Closing PowerPoint..')
-$Presentation.SaveAs($PPTFinalFile)
-$Presentation.Close()
-$Application.Quit()
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Closing PowerPoint..')
+    $Presentation.SaveAs($PPTFinalFile)
+    $Presentation.Close()
+    $Application.Quit()
 
-#if ($csvExport.IsPresent) {
+    #if ($csvExport.IsPresent) {
     $WorkloadRecommendationTemplate = Build-SummaryActionPlan -ImpactedResources $ExcelImpactedResources -includeLow $includeLow
 
     $CSVFile = ("$PWD\Impacted Resources and Recommendations Template " + (get-date -Format "yyyy-MM-dd-HH-mm") + '.csv')
 
     $WorkloadRecommendationTemplate | Export-Csv -Path $CSVFile
-#}
+    #}
 
-if (Get-Process -Name "POWERPNT" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' })
+    if (Get-Process -Name "POWERPNT" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' })
     {
         Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Trying to kill PowerPoint process.')
         Get-Process -Name "POWERPNT" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
     }
 
-if (Get-Process -Name "excel" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } )
+    if (Get-Process -Name "excel" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } )
     {
         Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Trying to kill Excel process.')
         Get-Process -Name "excel" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
     }
 
-Write-Progress -Id 1 -activity "Processing Office Apps" -Status "90% Complete." -PercentComplete 90
+    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "90% Complete." -PercentComplete 90
 
-Write-Progress -Id 1 -activity "Processing Office Apps" -Status "100% Complete." -Completed
+    Write-Progress -Id 1 -activity "Processing Office Apps" -Status "100% Complete." -Completed
 
-$stopwatch.Stop()
+    $stopwatch.Stop()
 
-################ Finishing
+    ################ Finishing
 
-Write-Host "---------------------------------------------------------------------"
-Write-Host ('Execution Complete. Total Runtime was: ') -NoNewline
-Write-Host $stopwatch.Elapsed.toString('hh\:mm\:ss') -ForegroundColor Cyan
-Write-Host 'PowerPoint File Saved as: ' -NoNewline
-Write-Host $PPTFinalFile -ForegroundColor Cyan
-Write-Host 'Assessment Findings File Saved as: ' -NoNewline
-Write-Host $NewAssessmentFindingsFile -ForegroundColor Cyan
+    Write-Host "---------------------------------------------------------------------"
+    Write-Host ('Execution Complete. Total Runtime was: ') -NoNewline
+    Write-Host $stopwatch.Elapsed.toString('hh\:mm\:ss') -ForegroundColor Cyan
+    Write-Host 'PowerPoint File Saved as: ' -NoNewline
+    Write-Host $PPTFinalFile -ForegroundColor Cyan
+    Write-Host 'Assessment Findings File Saved as: ' -NoNewline
+    Write-Host $NewAssessmentFindingsFile -ForegroundColor Cyan
 
-#if ($csvExport.IsPresent) {
+    #if ($csvExport.IsPresent) {
     Write-Host 'CSV File Saved as: ' -NoNewline
     Write-Host $CSVFile -ForegroundColor Cyan
-#}
+    #}
 
-Write-Host "---------------------------------------------------------------------"
+    Write-Host "---------------------------------------------------------------------"
+}
+catch {
+    $exceptionMessage = New-ExceptionMessage -ErrorRecord $_
+    $exceptionMessage | Write-Host -ForegroundColor Yellow
+}

--- a/src/modules/wara/reports/3_wara_reports_generator.ps1
+++ b/src/modules/wara/reports/3_wara_reports_generator.ps1
@@ -1509,8 +1509,8 @@ Write-Host 'Assessment Findings File Saved as: ' -NoNewline
 Write-Host $NewAssessmentFindingsFile -ForegroundColor Cyan
 
 #if ($csvExport.IsPresent) {
-Write-Host 'CSV File Saved as: ' -NoNewline
-Write-Host $CSVFile -ForegroundColor Cyan
+    Write-Host 'CSV File Saved as: ' -NoNewline
+    Write-Host $CSVFile -ForegroundColor Cyan
 #}
 
 Write-Host "---------------------------------------------------------------------"

--- a/src/modules/wara/reports/3_wara_reports_generator.ps1
+++ b/src/modules/wara/reports/3_wara_reports_generator.ps1
@@ -47,69 +47,6 @@ Param(
 
 $ErrorActionPreference = 'Stop'
 
-# Checking the operating system running this script.
-if (-not $IsWindows) {
-  Write-Host 'This script only supports Windows operating systems currently. Please try to run with Windows operating systems.'
-  Exit
-  }
-
-  # Check if Clipboard History is enabled
-$clipboardHistory = Get-ItemProperty -Path "HKCU:\Software\Microsoft\Clipboard" -Name "EnableClipboardHistory" -ErrorAction SilentlyContinue
-
-if ($clipboardHistory.EnableClipboardHistory -eq 1) {
-    Throw "Clipboard History is enabled. Please disable Clipboard History before running this script."
-} else {
-    Write-Debug "Clipboard History is disabled."
-}
-
-# TODO: Remove if not needed
-<# $CurrentPath = Get-Location
-$CurrentPath = $CurrentPath.Path #>
-if ($PSBoundParameters.ContainsKey('PPTTemplateFile')) {
-    # Resolve-Path throw exception if the path does not exist.
-    $pptTemplateFilePath = (Resolve-Path -LiteralPath $PPTTemplateFile).Path
-    if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
-        # The specified path is not a file, it may be a folder.
-        Write-Error -Message ('The specified PowerPoint template file "{0}" is not a file. Please provide the path to the PowerPoint template file.' -f $pptTemplateFilePath)
-        Exit  # TODO: This can be deleted after adding exception handling.
-    }
-}
-else {
-    $pptTemplateFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'Mandatory - Executive Summary presentation - Template.pptx'
-    if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
-        Write-Error -Message ('The default PowerPoint template file "{0}" does not exist. Please contact the WARA team via GitHub or Microsoft Teams.' -f $pptTemplateFilePath)  # TODO
-        Exit  # TODO: This can be deleted after adding exception handling.
-    }
-}
-Write-Host ('PowerPoint Template File: {0}' -f $pptTemplateFilePath)
-
-if (!$AssessmentFindingsFile) {
-  write-host ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx")
-  if ((Test-Path -Path ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx") -PathType Leaf) -eq $true) {
-    $AssessmentFindingsFile = ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx")
-  }
-  else {
-    Write-Error "Assessment Findings file is missing. Please provide the path to the Assessment Findings file."
-    Exit
-  }
-}
-
-if (!$ExpertAnalysisFile) {
-  Write-Host "The Expert-Analysis Excel file is missing. Please provide the path to the Expert-Analysis Excel file." -ForegroundColor Yellow
-  Exit
-}
-
-
-if (!$CustomerName) {
-  $CustomerName = '[Customer Name]'
-}
-
-if (!$WorkloadName) {
-  $WorkloadName = '[Workload Name]'
-}
-
-$TableStyle = 'Light19'
-
   ######################## REGULAR Functions ##########################
 
   function Test-ReviewedRecommendations {
@@ -1287,6 +1224,8 @@ function Build-ExcelPivotChart {
 
 }
 
+######################## Main Script Part ##########################
+
 # Start the stopwatch to time the script
 $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
@@ -1295,6 +1234,69 @@ $Version = "2.1.5"
 Write-Host "Version: " -NoNewline
 Write-Host $Version -ForegroundColor DarkBlue -NoNewline
 Write-Host " "
+
+# Checking the operating system running this script.
+if (-not $IsWindows) {
+  Write-Host 'This script only supports Windows operating systems currently. Please try to run with Windows operating systems.'
+  Exit
+  }
+
+  # Check if Clipboard History is enabled
+$clipboardHistory = Get-ItemProperty -Path "HKCU:\Software\Microsoft\Clipboard" -Name "EnableClipboardHistory" -ErrorAction SilentlyContinue
+
+if ($clipboardHistory.EnableClipboardHistory -eq 1) {
+    Throw "Clipboard History is enabled. Please disable Clipboard History before running this script."
+} else {
+    Write-Debug "Clipboard History is disabled."
+}
+
+# TODO: Remove if not needed
+<# $CurrentPath = Get-Location
+$CurrentPath = $CurrentPath.Path #>
+if ($PSBoundParameters.ContainsKey('PPTTemplateFile')) {
+    # Resolve-Path throw exception if the path does not exist.
+    $pptTemplateFilePath = (Resolve-Path -LiteralPath $PPTTemplateFile).Path
+    if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
+        # The specified path is not a file, it may be a folder.
+        Write-Error -Message ('The specified PowerPoint template file "{0}" is not a file. Please provide the path to the PowerPoint template file.' -f $pptTemplateFilePath)
+        Exit  # TODO: This can be deleted after adding exception handling.
+    }
+}
+else {
+    $pptTemplateFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'Mandatory - Executive Summary presentation - Template.pptx'
+    if (-not (Test-Path -PathType Leaf -LiteralPath $pptTemplateFilePath)) {
+        Write-Error -Message ('The default PowerPoint template file "{0}" does not exist. Please contact the WARA team via GitHub or Microsoft Teams.' -f $pptTemplateFilePath)  # TODO
+        Exit  # TODO: This can be deleted after adding exception handling.
+    }
+}
+Write-Host ('PowerPoint Template File: {0}' -f $pptTemplateFilePath)
+
+if (!$AssessmentFindingsFile) {
+  write-host ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx")
+  if ((Test-Path -Path ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx") -PathType Leaf) -eq $true) {
+    $AssessmentFindingsFile = ("$PSScriptRoot/Assessment-Findings-Report-v1.xlsx")
+  }
+  else {
+    Write-Error "Assessment Findings file is missing. Please provide the path to the Assessment Findings file."
+    Exit
+  }
+}
+
+if (!$ExpertAnalysisFile) {
+  Write-Host "The Expert-Analysis Excel file is missing. Please provide the path to the Expert-Analysis Excel file." -ForegroundColor Yellow
+  Exit
+}
+
+
+if (!$CustomerName) {
+  $CustomerName = '[Customer Name]'
+}
+
+if (!$WorkloadName) {
+  $WorkloadName = '[Workload Name]'
+}
+
+$TableStyle = 'Light19'
 
 $CoreFile = get-item -Path $ExpertAnalysisFile
 $CoreFile = $CoreFile.FullName

--- a/src/modules/wara/reports/3_wara_reports_generator.ps1
+++ b/src/modules/wara/reports/3_wara_reports_generator.ps1
@@ -45,6 +45,8 @@ Param(
   [string] $PPTTemplateFile
 )
 
+$ErrorActionPreference = 'Stop'
+
 # Checking the operating system running this script.
 if (-not $IsWindows) {
   Write-Host 'This script only supports Windows operating systems currently. Please try to run with Windows operating systems.'


### PR DESCRIPTION
# Overview/Summary

Adds better exception experience to Start-WARAReport by an exception handling that covering the entire script.

Changes:
- Sets the ErrorActionPreference to Stop.
- Adds a `trap` statement to catch exceptions over the entire script.
- Removes unnecessary exit statements after Write-Error.
- Refactor the parameter validation.
- Wrap the Office app part using the try-finally statement.

![image](https://github.com/user-attachments/assets/28bf8c18-1816-404f-9af7-6dafa1858d6e)

## Related Issues/Work Items

- AB#40801

### Breaking Changes

None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
