### PR TITLE
style: Format Start-WARAReport code

### DIFF
--- a/src/modules/wara/reports/3_wara_reports_generator.ps1
+++ b/src/modules/wara/reports/3_wara_reports_generator.ps1
@@ -33,27 +33,27 @@ https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2
 #>
 
 Param(
-  [switch] $Help,
+    [switch] $Help,
 
-  #[switch] $csvExport,
+    #[switch] $csvExport,
 
-  [switch] $includeLow,
+    [switch] $includeLow,
 
-  [Parameter(Mandatory = $false)]
-  [string] $CustomerName = '[Customer Name]',
+    [Parameter(Mandatory = $false)]
+    [string] $CustomerName = '[Customer Name]',
 
-  [Parameter(Mandatory = $false)]
-  [string] $WorkloadName = '[Workload Name]',
+    [Parameter(Mandatory = $false)]
+    [string] $WorkloadName = '[Workload Name]',
 
-  [Parameter(Mandatory = $true)]
-  [Alias('ExcelFile')]
-  [string] $ExpertAnalysisFile,
+    [Parameter(Mandatory = $true)]
+    [Alias('ExcelFile')]
+    [string] $ExpertAnalysisFile,
 
-  [Parameter(Mandatory = $false)]
-  [string] $AssessmentFindingsFile = (Join-Path -Path $PSScriptRoot -ChildPath 'Assessment-Findings-Report-v1.xlsx'),
+    [Parameter(Mandatory = $false)]
+    [string] $AssessmentFindingsFile = (Join-Path -Path $PSScriptRoot -ChildPath 'Assessment-Findings-Report-v1.xlsx'),
 
-  [Parameter(Mandatory = $false)]
-  [string] $PPTTemplateFile = (Join-Path -Path $PSScriptRoot -ChildPath 'Mandatory - Executive Summary presentation - Template.pptx')
+    [Parameter(Mandatory = $false)]
+    [string] $PPTTemplateFile = (Join-Path -Path $PSScriptRoot -ChildPath 'Mandatory - Executive Summary presentation - Template.pptx')
 )
 
 $ErrorActionPreference = 'Stop'
@@ -114,7 +114,8 @@ $clipboardHistory = Get-ItemProperty -Path 'HKCU:\Software\Microsoft\Clipboard' 
 
 if ($clipboardHistory.EnableClipboardHistory -eq 1) {
     throw 'Clipboard History is enabled. Please disable Clipboard History before running this script. See more details at https://aka.ms/waratools/faq'
-} else {
+}
+else {
     Write-Debug 'Clipboard History is disabled.'
 }
 
@@ -134,28 +135,26 @@ Write-Host ('Assessment Findings File: {0}' -f $assessmentFindingsFilePath)
 
 $TableStyle = 'Light19'
 
-  ######################## REGULAR Functions ##########################
+######################## REGULAR Functions ##########################
 
-  function Test-ReviewedRecommendations {
+function Test-ReviewedRecommendations {
     Param($ExcelFile)
 
     $ExcelContent = Import-Excel -Path $ExcelFile -WorksheetName '4.ImpactedResourcesAnalysis' -StartRow 12
 
-    if ( ($ExcelContent | Where-Object { $_.Impact -ne 'Low' -and $_.'REQUIRED ACTIONS / REVIEW STATUS' -ne 'Reviewed' -and ![String]::IsNullOrEmpty($_.'REQUIRED ACTIONS / REVIEW STATUS')}).count -ge 1)
-      {
+    if (($ExcelContent | Where-Object { $_.Impact -ne 'Low' -and $_.'REQUIRED ACTIONS / REVIEW STATUS' -ne 'Reviewed' -and ![String]::IsNullOrEmpty($_.'REQUIRED ACTIONS / REVIEW STATUS') }).count -ge 1) {
         Write-Host ""
         Write-Host "There are still some recommendations that need to be reviewed." -ForegroundColor Yellow
         Write-Host "Please review all the recommendations in the Expert-Analysis file before running the report generator." -ForegroundColor Yellow
         Write-Host ""
         Exit
-      }
+    }
+}
 
-  }
-
-  function New-AssessmentFindingsFile {
+function New-AssessmentFindingsFile {
     Param(
-      [string]$AssessmentFindingsFile
-      )
+        [string]$AssessmentFindingsFile
+    )
 
     $workingFolderPath = Get-Location
     $workingFolderPath = $workingFolderPath.Path
@@ -164,153 +163,145 @@ $TableStyle = 'Light19'
     Close-ExcelPackage -ExcelPackage $ExcelPkg -SaveAs $NewAssessmentFindings
 
     return $NewAssessmentFindings
-  }
+}
 
-  function New-PPTFile {
+function New-PPTFile {
     Param(
-      [string]$PPTTemplateFile  # NEED FIX: PPTTemplateFile parameter does not use in the function
-      )
+        [string]$PPTTemplateFile  # NEED FIX: PPTTemplateFile parameter does not use in the function
+    )
 
     $workingFolderPath = Get-Location
     $workingFolderPath = $workingFolderPath.Path
     $NewPPTFile = ($workingFolderPath + '\Executive Summary Presentation - ' + $CustomerName + ' - ' + (get-date -Format "yyyy-MM-dd-HH-mm") + '.pptx')
 
     return $NewPPTFile
-  }
+}
 
-  function Test-Requirement {
+function Test-Requirement {
     # Install required modules
     Write-Host "Validating " -NoNewline
     Write-Host "ImportExcel" -ForegroundColor Cyan -NoNewline
     Write-Host " Module.."
     $ImportExcel = Get-Module -Name ImportExcel -ListAvailable -ErrorAction silentlycontinue
     if ($null -eq $ImportExcel) {
-      Write-Host "Installing ImportExcel Module" -ForegroundColor Yellow
-      Install-Module -Name ImportExcel -Force -SkipPublisherCheck
+        Write-Host "Installing ImportExcel Module" -ForegroundColor Yellow
+        Install-Module -Name ImportExcel -Force -SkipPublisherCheck
     }
-  }
+}
 
-  function Set-LocalFile {
+function Set-LocalFile {
     # Define script path as the default path to save files
-      $workingFolderPath = $PSScriptRoot
-      Set-Location -path $workingFolderPath;
-      $clonePath = "$workingFolderPath\Azure-Proactive-Resiliency-Library"
-      Write-Debug "Checking the version of the script"
-      $RepoVersion = Get-Content -Path "$clonePath\tools\Version.json" -ErrorAction SilentlyContinue | ConvertFrom-Json
-      if ($Version -ne $RepoVersion.Generator) {
+    $workingFolderPath = $PSScriptRoot
+    Set-Location -path $workingFolderPath;
+    $clonePath = "$workingFolderPath\Azure-Proactive-Resiliency-Library"
+    Write-Debug "Checking the version of the script"
+    $RepoVersion = Get-Content -Path "$clonePath\tools\Version.json" -ErrorAction SilentlyContinue | ConvertFrom-Json
+    if ($Version -ne $RepoVersion.Generator) {
         Write-Host "This version of the script is outdated. " -BackgroundColor DarkRed
         Write-Host "Please use a more recent version of the script." -BackgroundColor DarkRed
-      }
-      else {
+    }
+    else {
         Write-Host "This version of the script is current version. " -BackgroundColor DarkGreen
-      }
+    }
+}
 
-  }
-
-  function Get-ExcelImpactedResources {
+function Get-ExcelImpactedResources {
     Param($ExcelFile)
 
     $ExcelContent = Import-Excel -Path $ExcelFile -WorksheetName '4.ImpactedResourcesAnalysis' -StartRow 12
     #$ImpactedResources = $ExcelContent
 
-    return $ExcelContent.where({![String]::IsNullOrEmpty($_."Resource Type")})
-  }
+    return $ExcelContent.where({ ![String]::IsNullOrEmpty($_."Resource Type") })
+}
 
-  function Get-ExcelWorkloadInventory {
+function Get-ExcelWorkloadInventory {
     Param($ExcelFile)
 
     $ExcelContent = Import-Excel -Path $ExcelFile -WorksheetName '2.WorkloadInventory' -StartRow 12
 
     return $ExcelContent
+}
 
-  }
-
-  function Get-ExcelPlatformIssues {
+function Get-ExcelPlatformIssues {
     Param($ExcelFile)
 
     try {
-      $PlatformIssues = Import-Excel -Path $ExcelFile -WorksheetName '5.PlatformIssuesAnalysis' -StartRow 12
+        $PlatformIssues = Import-Excel -Path $ExcelFile -WorksheetName '5.PlatformIssuesAnalysis' -StartRow 12
     }
     catch {
-      Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Platform Issues not found in the Excel File..')
+        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Platform Issues not found in the Excel File..')
     }
 
     return $PlatformIssues
+}
 
-  }
-
-  function Get-ExcelSupportTicket {
+function Get-ExcelSupportTicket {
     Param($ExcelFile)
 
     try {
-      $SupportTickets = Import-Excel -Path $ExcelFile -WorksheetName "6.SupportRequestsAnalysis" -AsText 'Ticket ID' -StartRow 12
+        $SupportTickets = Import-Excel -Path $ExcelFile -WorksheetName "6.SupportRequestsAnalysis" -AsText 'Ticket ID' -StartRow 12
     }
     catch {
-      Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Support Tickets not found in the Excel File..')
+        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Support Tickets not found in the Excel File..')
     }
 
     return $SupportTickets
-  }
+}
 
-  function Get-ExcelRetirement {
+function Get-ExcelRetirement {
     Param($ExcelFile)
 
     try {
-      $Retirements = Import-Excel -Path $ExcelFile -WorksheetName "4.ImpactedResourcesAnalysis" -StartRow 12
-      $Retirements = $Retirements | Where-Object {$_.Source -eq 'Azure Service Health - Service Retirements'}
+        $Retirements = Import-Excel -Path $ExcelFile -WorksheetName "4.ImpactedResourcesAnalysis" -StartRow 12
+        $Retirements = $Retirements | Where-Object { $_.Source -eq 'Azure Service Health - Service Retirements' }
     }
     catch {
-      Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Service Retirements not found in the Excel File..')
+        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Service Retirements not found in the Excel File..')
     }
 
     return $Retirements
+}
 
-  }
+function Build-SummaryActionPlan {
+    Param($ImpactedResources, $includeLow)
 
-  function Build-SummaryActionPlan {
-    Param($ImpactedResources,$includeLow)
-
-    if ($includeLow.IsPresent)
-      {
-        $Recommendations = $ImpactedResources | Where-Object {$_.impact -in ('High','Medium','Low') -and $_.ValidationCategory -ne 'Retirements'}
-      }
-    else
-      {
-        $Recommendations = $ImpactedResources | Where-Object {$_.impact -in ('High','Medium') -and $_.ValidationCategory -ne 'Retirements'}
-      }
+    if ($includeLow.IsPresent) {
+        $Recommendations = $ImpactedResources | Where-Object { $_.impact -in ('High', 'Medium', 'Low') -and $_.ValidationCategory -ne 'Retirements' }
+    }
+    else {
+        $Recommendations = $ImpactedResources | Where-Object { $_.impact -in ('High', 'Medium') -and $_.ValidationCategory -ne 'Retirements' }
+    }
 
     $RecomCount = ($ImpactedResources).count
-    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Creating CSV file for: '+ $RecomCount +' recommendations')
+    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Creating CSV file for: ' + $RecomCount + ' recommendations')
 
-    $CXSummaryArray = Foreach ($Recommendation in $Recommendations)
-      {
-
-        try{
-        $tmp = [PSCustomObject]@{
-          'Recommendation Guid'       = $Recommendation.Guid
-          'Recommendation Title'      = $Recommendation.'Recommendation Title'
-          'Description'               = $Recommendation.'Long Description'
-          'Priority'                  = $Recommendation.Impact
-          'Customer-facing annotation' = ""
-          'Internal-facing notes'     = $Recommendation.notes
-          'Potential Benefit'         = $Recommendation.'Potential Benefit'
-          'Resource Type'             = $Recommendation.'Resource Type'
-          'Resource ID'               = $Recommendation.id
+    $CXSummaryArray = foreach ($Recommendation in $Recommendations) {
+        try {
+            $tmp = [PSCustomObject]@{
+                'Recommendation Guid'        = $Recommendation.Guid
+                'Recommendation Title'       = $Recommendation.'Recommendation Title'
+                'Description'                = $Recommendation.'Long Description'
+                'Priority'                   = $Recommendation.Impact
+                'Customer-facing annotation' = ""
+                'Internal-facing notes'      = $Recommendation.notes
+                'Potential Benefit'          = $Recommendation.'Potential Benefit'
+                'Resource Type'              = $Recommendation.'Resource Type'
+                'Resource ID'                = $Recommendation.id
+            }
+            $tmp
         }
-        $tmp
-    } catch {
-      Write-Debug $recommendation
-      }
+        catch {
+            Write-Debug $recommendation
+        }
     }
     return $CXSummaryArray
+}
 
-  }
+######################## PPT Functions ##########################
 
-  ######################## PPT Functions ##########################
-
-  ############# Slide 1
-  function Remove-PPTSlide1 {
-    Param($Presentation,$CustomerName,$WorkloadName)
+############# Slide 1
+function Remove-PPTSlide1 {
+    Param($Presentation, $CustomerName, $WorkloadName)
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Removing Slide 1..')
 
     ($Presentation.Slides | Where-Object { $_.SlideIndex -eq 1 }).Delete()
@@ -319,11 +310,11 @@ $TableStyle = 'Light19'
 
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Slide 1 - Adding Customer name: ' + $CustomerName + '. And Workload name: ' + $WorkloadName)
     ($Slide1.Shapes | Where-Object { $_.Id -eq 5 }).TextFrame.TextRange.Text = ($CustomerName + ' - ' + $WorkloadName)
-  }
+}
 
-  ############# SLide 12
-  function Build-PPTSlide12 {
-    Param($Presentation,$AUTOMESSAGE,$WorkloadName,$ResourcesTypes)
+############# SLide 12
+function Build-PPTSlide12 {
+    Param($Presentation, $AUTOMESSAGE, $WorkloadName, $ResourcesTypes)
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 12 - Workload Summary..')
 
     $SlideWorkloadSummary = $Presentation.Slides | Where-Object { $_.SlideIndex -eq 12 }
@@ -339,27 +330,27 @@ $TableStyle = 'Light19'
 
     $loop = 1
     foreach ($ResourcesType in $ResourcesTypes) {
-      $LogResName = $ResourcesType.Name
-      $LogResCount = $ResourcesType.'Count'
-      Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 12 - Adding Resource Type: ' + $LogResName + '. Count: ' + $LogResCount)
-      if ($loop -eq 1) {
-        $ResourceTemp = ($ResourcesType.Name + ' (' + $ResourcesType.'Count' + ')')
-        ($SlideWorkloadSummary.Shapes | Where-Object { $_.Id -eq 6 }).Table.Columns(1).Width = 685
-        ($SlideWorkloadSummary.Shapes | Where-Object { $_.Id -eq 6 }).Table.Rows(1).Cells(1).Shape.TextFrame.TextRange.Text = $ResourceTemp
-        ($SlideWorkloadSummary.Shapes | Where-Object { $_.Id -eq 6 }).Table.Rows(1).Height = 20
-      }
-      else {
-        $ResourceTemp = ($ResourcesType.Name + ' (' + $ResourcesType.'Count' + ')')
-        ($SlideWorkloadSummary.Shapes | Where-Object { $_.Id -eq 6 }).Table.Rows.Add() | Out-Null
-        ($SlideWorkloadSummary.Shapes | Where-Object { $_.Id -eq 6 }).Table.Rows($loop).Cells(1).Shape.TextFrame.TextRange.Text = $ResourceTemp
-      }
-      $loop ++
+        $LogResName = $ResourcesType.Name
+        $LogResCount = $ResourcesType.'Count'
+        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 12 - Adding Resource Type: ' + $LogResName + '. Count: ' + $LogResCount)
+        if ($loop -eq 1) {
+            $ResourceTemp = ($ResourcesType.Name + ' (' + $ResourcesType.'Count' + ')')
+            ($SlideWorkloadSummary.Shapes | Where-Object { $_.Id -eq 6 }).Table.Columns(1).Width = 685
+            ($SlideWorkloadSummary.Shapes | Where-Object { $_.Id -eq 6 }).Table.Rows(1).Cells(1).Shape.TextFrame.TextRange.Text = $ResourceTemp
+            ($SlideWorkloadSummary.Shapes | Where-Object { $_.Id -eq 6 }).Table.Rows(1).Height = 20
+        }
+        else {
+            $ResourceTemp = ($ResourcesType.Name + ' (' + $ResourcesType.'Count' + ')')
+            ($SlideWorkloadSummary.Shapes | Where-Object { $_.Id -eq 6 }).Table.Rows.Add() | Out-Null
+            ($SlideWorkloadSummary.Shapes | Where-Object { $_.Id -eq 6 }).Table.Rows($loop).Cells(1).Shape.TextFrame.TextRange.Text = $ResourceTemp
+        }
+        $loop ++
     }
-  }
+}
 
-  ############# Slide 16
-  function Build-PPTSlide16 {
-    Param($Presentation,$AUTOMESSAGE,$ImpactedResources)
+############# Slide 16
+function Build-PPTSlide16 {
+    Param($Presentation, $AUTOMESSAGE, $ImpactedResources)
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 16 - Health and Risk Dashboard..')
 
     $SlideHealthAndRisk = $Presentation.Slides | Where-Object { $_.SlideIndex -eq 16 }
@@ -372,17 +363,16 @@ $TableStyle = 'Light19'
 
     $count = 1
     foreach ($Impact in $ServiceHighImpact) {
-      $LogImpactName = $Impact.Name
-      Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 16 - Adding Service High Impact Name: ' + $LogImpactName)
-      if ($count -lt 7) {
-          ($SlideHealthAndRisk.Shapes | Where-Object { $_.Id -eq 9 }).TextFrame.TextRange.Paragraphs($count).text = $Impact.Name
-        $count ++
-      }
+        $LogImpactName = $Impact.Name
+        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 16 - Adding Service High Impact Name: ' + $LogImpactName)
+        if ($count -lt 7) {
+            ($SlideHealthAndRisk.Shapes | Where-Object { $_.Id -eq 9 }).TextFrame.TextRange.Paragraphs($count).text = $Impact.Name
+            $count ++
+        }
     }
 
-
     while (($SlideHealthAndRisk.Shapes | Where-Object { $_.Id -eq 9 }).TextFrame.TextRange.Paragraphs().count -gt 6) {
-      ($SlideHealthAndRisk.Shapes | Where-Object { $_.Id -eq 9 }).TextFrame.TextRange.Paragraphs(6).Delete()
+        ($SlideHealthAndRisk.Shapes | Where-Object { $_.Id -eq 9 }).TextFrame.TextRange.Paragraphs(6).Delete()
     }
 
     <#
@@ -418,10 +408,10 @@ $TableStyle = 'Light19'
     ($SlideHealthAndRisk.Shapes | Where-Object { $_.Id -eq 24 }).TextFrame.TextRange.Text = [string]($ImpactedResources | Where-Object { $_.Impact -eq 'Low' } | Select-Object -Property Guid -Unique).count
     #Impacted Resources
     ($SlideHealthAndRisk.Shapes | Where-Object { $_.Id -eq 30 }).TextFrame.TextRange.Text = [string]($ImpactedResources | Select-Object -Property id -Unique).count
-  }
+}
 
-    ############# Slide 17
-  function Build-PPTSlide17 {
+############# Slide 17
+function Build-PPTSlide17 {
     Param($Presentation, $AUTOMESSAGE, $ExcelWorkbooks)
 
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 17 - Health and Risk Dashboard..')
@@ -464,16 +454,14 @@ $TableStyle = 'Light19'
     $yAxis.TickLabelSpacing = 1
     $Shape.IncrementLeft(240)
     Start-Sleep -Milliseconds 500
+}
 
-
-  }
-
-  ############# Slide 23
-  function Build-PPTSlide23 {
-    Param($Presentation,$AUTOMESSAGE,$ImpactedResources)
+############# Slide 23
+function Build-PPTSlide23 {
+    Param($Presentation, $AUTOMESSAGE, $ImpactedResources)
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 23 - High Impact Issues..')
 
-    $HighImpact = $ImpactedResources | Where-Object { $_.Impact -eq 'High' } | Group-Object -Property 'Recommendation Title','Resource Type' | Sort-Object -Property "Count" -Descending
+    $HighImpact = $ImpactedResources | Where-Object { $_.Impact -eq 'High' } | Group-Object -Property 'Recommendation Title', 'Resource Type' | Sort-Object -Property "Count" -Descending
 
     $FirstSlide = 23
     $TableID = 6
@@ -485,79 +473,78 @@ $TableStyle = 'Light19'
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 23 - Cleaning Table..')
     $row = 2
     while ($row -lt 6) {
-      $cell = 1
-      while ($cell -lt 5) {
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells($cell).Shape.TextFrame.TextRange.Text = ''
-        $Cell ++
-      }
-      $row ++
+        $cell = 1
+        while ($cell -lt 5) {
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells($cell).Shape.TextFrame.TextRange.Text = ''
+            $Cell ++
+        }
+        $row ++
     }
 
     $Counter = 1
     $RecomNumber = 1
     $row = 2
     foreach ($Impact in $HighImpact) {
-      $LogHighImpact = $Impact.Values[0]
-      Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 23 - Adding High Impact: ' + $LogHighImpact )
-      if ($Counter -lt 14) {
-        #Number
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(1).Shape.TextFrame.TextRange.Text = [string]$RecomNumber
-        #Recommendation
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(2).Shape.TextFrame.TextRange.Text = $Impact.Values[0]
-        #Service
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(3).Shape.TextFrame.TextRange.Text = $Impact.Values[1]
-        #Impacted Resources
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(4).Shape.TextFrame.TextRange.Text = [string]$Impact.'Count'
-        $counter ++
-        $RecomNumber ++
-        $row ++
-      }
-      else {
-        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 23 - Adding new Slide..')
-        $Counter = 1
-
-        $Presentation.slides[$FirstSlide].Duplicate() | Out-Null
-
-        $FirstSlide ++
-
-        $NextSlide = $Presentation.Slides | Where-Object { $_.SlideIndex -eq $FirstSlide }
-
-        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 23 - Cleaning table of new slide..')
-        $rowTemp = 2
-        while ($rowTemp -lt 15) {
-          $cell = 1
-          while ($cell -lt 5) {
-            ($NextSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($rowTemp).Cells($cell).Shape.TextFrame.TextRange.Text = ''
-            $Cell ++
-          }
-          $rowTemp ++
+        $LogHighImpact = $Impact.Values[0]
+        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 23 - Adding High Impact: ' + $LogHighImpact )
+        if ($Counter -lt 14) {
+            #Number
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(1).Shape.TextFrame.TextRange.Text = [string]$RecomNumber
+            #Recommendation
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(2).Shape.TextFrame.TextRange.Text = $Impact.Values[0]
+            #Service
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(3).Shape.TextFrame.TextRange.Text = $Impact.Values[1]
+            #Impacted Resources
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(4).Shape.TextFrame.TextRange.Text = [string]$Impact.'Count'
+            $counter ++
+            $RecomNumber ++
+            $row ++
         }
+        else {
+            Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 23 - Adding new Slide..')
+            $Counter = 1
 
-        $CurrentSlide = $NextSlide
+            $Presentation.slides[$FirstSlide].Duplicate() | Out-Null
 
-        $row = 2
-        #Number
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(1).Shape.TextFrame.TextRange.Text = [string]$RecomNumber
-        #Recommendation
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(2).Shape.TextFrame.TextRange.Text = $Impact.Values[0]
-        #Service
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(3).Shape.TextFrame.TextRange.Text = $Impact.Values[1]
-        #Impacted Resources
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(4).Shape.TextFrame.TextRange.Text = [string]$Impact.'Count'
-        $Counter ++
-        $RecomNumber ++
-        $row ++
-      }
+            $FirstSlide ++
+
+            $NextSlide = $Presentation.Slides | Where-Object { $_.SlideIndex -eq $FirstSlide }
+
+            Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 23 - Cleaning table of new slide..')
+            $rowTemp = 2
+            while ($rowTemp -lt 15) {
+                $cell = 1
+                while ($cell -lt 5) {
+                    ($NextSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($rowTemp).Cells($cell).Shape.TextFrame.TextRange.Text = ''
+                    $Cell ++
+                }
+                $rowTemp ++
+            }
+
+            $CurrentSlide = $NextSlide
+
+            $row = 2
+            #Number
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(1).Shape.TextFrame.TextRange.Text = [string]$RecomNumber
+            #Recommendation
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(2).Shape.TextFrame.TextRange.Text = $Impact.Values[0]
+            #Service
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(3).Shape.TextFrame.TextRange.Text = $Impact.Values[1]
+            #Impacted Resources
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(4).Shape.TextFrame.TextRange.Text = [string]$Impact.'Count'
+            $Counter ++
+            $RecomNumber ++
+            $row ++
+        }
     }
+}
 
-  }
-
-  ############# Slide 24
-  function Build-PPTSlide24 {
-    Param($Presentation,$AUTOMESSAGE,$ImpactedResources)
+############# Slide 24
+function Build-PPTSlide24 {
+    Param($Presentation, $AUTOMESSAGE, $ImpactedResources)
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 24 - Medium Impact Issues..')
 
-    $MediumImpact = $ImpactedResources | Where-Object { $_.Impact -eq 'Medium' } | Group-Object -Property 'Recommendation Title','Resource Type' | Sort-Object -Property "Count" -Descending
+    $MediumImpact = $ImpactedResources | Where-Object { $_.Impact -eq 'Medium' } | Group-Object -Property 'Recommendation Title', 'Resource Type' | Sort-Object -Property "Count" -Descending
 
     $FirstSlide = 24
     $TableID = 6
@@ -569,79 +556,78 @@ $TableStyle = 'Light19'
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 24 - Cleaning Table..')
     $row = 2
     while ($row -lt 6) {
-      $cell = 1
-      while ($cell -lt 5) {
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells($cell).Shape.TextFrame.TextRange.Text = ''
-        $Cell ++
-      }
-      $row ++
+        $cell = 1
+        while ($cell -lt 5) {
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells($cell).Shape.TextFrame.TextRange.Text = ''
+            $Cell ++
+        }
+        $row ++
     }
 
     $Counter = 1
     $RecomNumber = 1
     $row = 2
     foreach ($Impact in $MediumImpact) {
-      $LogMediumImpact = $Impact.Values[0]
-      Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 24 - Adding Medium Impact: ' + $LogMediumImpact)
-      if ($Counter -lt 14) {
-        #Number
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(1).Shape.TextFrame.TextRange.Text = [string]$RecomNumber
-        #Recommendation
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(2).Shape.TextFrame.TextRange.Text = $Impact.Values[0]
-        #Service
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(3).Shape.TextFrame.TextRange.Text = $Impact.Values[1]
-        #Impacted Resources
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(4).Shape.TextFrame.TextRange.Text = [string]$Impact.'Count'
-        $counter ++
-        $RecomNumber ++
-        $row ++
-      }
-      else {
-        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 24 - Creating new slide..')
-        $Counter = 1
-
-        $Presentation.slides[$FirstSlide].Duplicate() | Out-Null
-
-        $FirstSlide ++
-
-        $NextSlide = $Presentation.Slides | Where-Object { $_.SlideIndex -eq $FirstSlide }
-
-        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 24 - Cleaning Table of new slide..')
-        $rowTemp = 2
-        while ($rowTemp -lt 15) {
-          $cell = 1
-          while ($cell -lt 5) {
-            ($NextSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($rowTemp).Cells($cell).Shape.TextFrame.TextRange.Text = ''
-            $Cell ++
-          }
-          $rowTemp ++
+        $LogMediumImpact = $Impact.Values[0]
+        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 24 - Adding Medium Impact: ' + $LogMediumImpact)
+        if ($Counter -lt 14) {
+            #Number
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(1).Shape.TextFrame.TextRange.Text = [string]$RecomNumber
+            #Recommendation
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(2).Shape.TextFrame.TextRange.Text = $Impact.Values[0]
+            #Service
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(3).Shape.TextFrame.TextRange.Text = $Impact.Values[1]
+            #Impacted Resources
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(4).Shape.TextFrame.TextRange.Text = [string]$Impact.'Count'
+            $counter ++
+            $RecomNumber ++
+            $row ++
         }
+        else {
+            Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 24 - Creating new slide..')
+            $Counter = 1
 
-        $CurrentSlide = $NextSlide
+            $Presentation.slides[$FirstSlide].Duplicate() | Out-Null
 
-        $row = 2
-        #Number
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(1).Shape.TextFrame.TextRange.Text = [string]$RecomNumber
-        #Recommendation
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(2).Shape.TextFrame.TextRange.Text = $Impact.Values[0]
-        #Service
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(3).Shape.TextFrame.TextRange.Text = $Impact.Values[1]
-        #Impacted Resources
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(4).Shape.TextFrame.TextRange.Text = [string]$Impact.'Count'
-        $Counter ++
-        $RecomNumber ++
-        $row ++
-      }
+            $FirstSlide ++
+
+            $NextSlide = $Presentation.Slides | Where-Object { $_.SlideIndex -eq $FirstSlide }
+
+            Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 24 - Cleaning Table of new slide..')
+            $rowTemp = 2
+            while ($rowTemp -lt 15) {
+                $cell = 1
+                while ($cell -lt 5) {
+                    ($NextSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($rowTemp).Cells($cell).Shape.TextFrame.TextRange.Text = ''
+                    $Cell ++
+                }
+                $rowTemp ++
+            }
+
+            $CurrentSlide = $NextSlide
+
+            $row = 2
+            #Number
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(1).Shape.TextFrame.TextRange.Text = [string]$RecomNumber
+            #Recommendation
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(2).Shape.TextFrame.TextRange.Text = $Impact.Values[0]
+            #Service
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(3).Shape.TextFrame.TextRange.Text = $Impact.Values[1]
+            #Impacted Resources
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(4).Shape.TextFrame.TextRange.Text = [string]$Impact.'Count'
+            $Counter ++
+            $RecomNumber ++
+            $row ++
+        }
     }
+}
 
-  }
-
-  ############# Slide 25
-  function Build-PPTSlide25 {
-    Param($Presentation,$AUTOMESSAGE,$ImpactedResources)
+############# Slide 25
+function Build-PPTSlide25 {
+    Param($Presentation, $AUTOMESSAGE, $ImpactedResources)
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 25 - Low Impact Issues..')
 
-    $LowImpact = $ImpactedResources | Where-Object { $_.Impact -eq 'Low' } | Group-Object -Property 'Recommendation Title','Resource Type' | Sort-Object -Property "Count" -Descending
+    $LowImpact = $ImpactedResources | Where-Object { $_.Impact -eq 'Low' } | Group-Object -Property 'Recommendation Title', 'Resource Type' | Sort-Object -Property "Count" -Descending
 
     $FirstSlide = 25
     $TableID = 6
@@ -653,86 +639,84 @@ $TableStyle = 'Light19'
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 25 - Cleaning Table..')
     $row = 2
     while ($row -lt 6) {
-      $cell = 1
-      while ($cell -lt 5) {
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells($cell).Shape.TextFrame.TextRange.Text = ''
-        $Cell ++
-      }
-      $row ++
+        $cell = 1
+        while ($cell -lt 5) {
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells($cell).Shape.TextFrame.TextRange.Text = ''
+            $Cell ++
+        }
+        $row ++
     }
 
     $Counter = 1
     $RecomNumber = 1
     $row = 2
     foreach ($Impact in $LowImpact) {
-      $LogLowImpact = $Impact.Values[0]
-      Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 25 - Adding Low Impact: ' + $LogLowImpact)
-      if ($Counter -lt 14) {
-        #Number
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(1).Shape.TextFrame.TextRange.Text = [string]$RecomNumber
-        #Recommendation
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(2).Shape.TextFrame.TextRange.Text = $Impact.Values[0]
-        #Service
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(3).Shape.TextFrame.TextRange.Text = $Impact.Values[1]
-        #Impacted Resources
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(4).Shape.TextFrame.TextRange.Text = [string]$Impact.'Count'
-        $counter ++
-        $RecomNumber ++
-        $row ++
-      }
-      else {
-        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 25 - Creating new Slide..')
-        $Counter = 1
-
-        $Presentation.slides[$FirstSlide].Duplicate() | Out-Null
-
-        $FirstSlide ++
-
-        $NextSlide = $Presentation.Slides | Where-Object { $_.SlideIndex -eq $FirstSlide }
-
-        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 25 - Cleaning Table of new slide..')
-        $rowTemp = 2
-        while ($rowTemp -lt 15) {
-          $cell = 1
-          while ($cell -lt 5) {
-            ($NextSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($rowTemp).Cells($cell).Shape.TextFrame.TextRange.Text = ''
-            $Cell ++
-          }
-          $rowTemp ++
+        $LogLowImpact = $Impact.Values[0]
+        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 25 - Adding Low Impact: ' + $LogLowImpact)
+        if ($Counter -lt 14) {
+            #Number
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(1).Shape.TextFrame.TextRange.Text = [string]$RecomNumber
+            #Recommendation
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(2).Shape.TextFrame.TextRange.Text = $Impact.Values[0]
+            #Service
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(3).Shape.TextFrame.TextRange.Text = $Impact.Values[1]
+            #Impacted Resources
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(4).Shape.TextFrame.TextRange.Text = [string]$Impact.'Count'
+            $counter ++
+            $RecomNumber ++
+            $row ++
         }
+        else {
+            Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 25 - Creating new Slide..')
+            $Counter = 1
 
-        $CurrentSlide = $NextSlide
+            $Presentation.slides[$FirstSlide].Duplicate() | Out-Null
 
-        $row = 2
-        #Number
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(1).Shape.TextFrame.TextRange.Text = [string]$RecomNumber
-        #Recommendation
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(2).Shape.TextFrame.TextRange.Text = $Impact.Values[0]
-        #Service
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(3).Shape.TextFrame.TextRange.Text = $Impact.Values[1]
-        #Impacted Resources
-        ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(4).Shape.TextFrame.TextRange.Text = [string]$Impact.'Count'
-        $Counter ++
-        $RecomNumber ++
-        $row ++
-      }
+            $FirstSlide ++
+
+            $NextSlide = $Presentation.Slides | Where-Object { $_.SlideIndex -eq $FirstSlide }
+
+            Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 25 - Cleaning Table of new slide..')
+            $rowTemp = 2
+            while ($rowTemp -lt 15) {
+                $cell = 1
+                while ($cell -lt 5) {
+                    ($NextSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($rowTemp).Cells($cell).Shape.TextFrame.TextRange.Text = ''
+                    $Cell ++
+                }
+                $rowTemp ++
+            }
+
+            $CurrentSlide = $NextSlide
+
+            $row = 2
+            #Number
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(1).Shape.TextFrame.TextRange.Text = [string]$RecomNumber
+            #Recommendation
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(2).Shape.TextFrame.TextRange.Text = $Impact.Values[0]
+            #Service
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(3).Shape.TextFrame.TextRange.Text = $Impact.Values[1]
+            #Impacted Resources
+            ($CurrentSlide.Shapes | Where-Object { $_.Id -eq $TableID }).Table.Rows($row).Cells(4).Shape.TextFrame.TextRange.Text = [string]$Impact.'Count'
+            $Counter ++
+            $RecomNumber ++
+            $row ++
+        }
     }
+}
 
-  }
-
-  ############# Slide 28
-  function Build-PPTSlide28 {
-    Param($Presentation,$AUTOMESSAGE,$PlatformIssues)
+############# Slide 28
+function Build-PPTSlide28 {
+    Param($Presentation, $AUTOMESSAGE, $PlatformIssues)
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 28 - Recent Microsoft Outages..')
 
     $Loop = 1
     $CurrentSlide = 28
 
     if (![string]::IsNullOrEmpty($PlatformIssues)) {
-      Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 28 - Outages found..')
-      foreach ($Outage in $PlatformIssues) {
-        if (![string]::IsNullOrEmpty($Outage.title))
-            {
+        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 28 - Outages found..')
+        foreach ($Outage in $PlatformIssues) {
+            if (![string]::IsNullOrEmpty($Outage.title)) {
                 if ($Loop -eq 1) {
                     $OutageName = ($Outage.'Tracking ID' + ' - ' + $Outage.title)
                     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 28 - Adding Outage: ' + $OutageName)
@@ -753,10 +737,10 @@ $TableStyle = 'Light19'
                     ($SlidePlatformIssues.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(7).Text = $Outage.'How can customers make incidents like this less impactful'
 
                     while (($SlidePlatformIssues.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs().count -gt 7) {
-                      ($SlidePlatformIssues.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(8).Delete()
+                        ($SlidePlatformIssues.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(8).Delete()
                     }
-                  }
-                  else {
+                }
+                else {
                     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 28 - Creating new Slide..')
                     ############### NEXT 9 SLIDES
 
@@ -780,18 +764,18 @@ $TableStyle = 'Light19'
                     ($NextSlide.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(7).Text = $Outage.'How can customers make incidents like this less impactful'
 
                     while (($NextSlide.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs().count -gt 7) {
-                      ($NextSlide.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(8).Delete()
+                        ($NextSlide.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(8).Delete()
                     }
-                  }
-                  $Loop ++
+                }
+                $Loop ++
             }
-      }
+        }
     }
-  }
+}
 
-  ############# Slide 29
-  function Build-PPTSlide29 {
-    Param($Presentation,$AUTOMESSAGE,$SupportTickets)
+############# Slide 29
+function Build-PPTSlide29 {
+    Param($Presentation, $AUTOMESSAGE, $SupportTickets)
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 29 - Sev-A Support Requests..')
 
     $Loop = 1
@@ -799,8 +783,7 @@ $TableStyle = 'Light19'
     $Slide = 1
 
     # Prevents the script from creating the SupportTickets slide if there are no support tickets
-    if(!($SupportTickets.count -eq 1 -and [string]::IsNullOrEmpty($SupportTickets.'Ticket ID')))
-    {
+    if (!($SupportTickets.count -eq 1 -and [string]::IsNullOrEmpty($SupportTickets.'Ticket ID'))) {
         Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 29 - Support Tickets found..')
         foreach ($Tickets in $SupportTickets) {
             $TicketName = ($Tickets.'Ticket ID' + ' - ' + $Tickets.Title)
@@ -808,106 +791,104 @@ $TableStyle = 'Light19'
             $TicketStatus = $Tickets.'Status'
             $TicketDate = $Tickets.'Creation Date'
 
-        if ($Slide -eq 1) {
-            if ($Loop -eq 1) {
-                $SlideSupportRequests = $Presentation.Slides | Where-Object { $_.SlideIndex -eq 29 }
-                $TargetShape = ($SlideSupportRequests.Shapes | Where-Object { $_.Id -eq 4 })
-                $TargetShape.TextFrame.TextRange.Text = $AUTOMESSAGE
+            if ($Slide -eq 1) {
+                if ($Loop -eq 1) {
+                    $SlideSupportRequests = $Presentation.Slides | Where-Object { $_.SlideIndex -eq 29 }
+                    $TargetShape = ($SlideSupportRequests.Shapes | Where-Object { $_.Id -eq 4 })
+                    $TargetShape.TextFrame.TextRange.Text = $AUTOMESSAGE
 
-                ($SlideSupportRequests.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(1).Text = $TicketName
-                ($SlideSupportRequests.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(2).Text = "Status: $TicketStatus"
-                ($SlideSupportRequests.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(3).Text = "Creation Date: $TicketDate"
+                    ($SlideSupportRequests.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(1).Text = $TicketName
+                    ($SlideSupportRequests.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(2).Text = "Status: $TicketStatus"
+                    ($SlideSupportRequests.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(3).Text = "Creation Date: $TicketDate"
 
-                $Loop ++
-            }
-            else {
-
-                $newtextbox = ($SlideSupportRequests.Shapes | Where-Object { $_.Id -eq 7 }).Duplicate()
-
-                if ($Loop -eq 2) {
-                    $newtextbox.name = 'Shape2'
-                    $newtextbox.top = [int]$newtextbox.top + 100
-                    $newtextbox.left = [int]$newtextbox.left - 10
-                }
-                elseif ($Loop -eq 3) {
-                    $newtextbox.name = 'Shape3'
-                    $newtextbox.top = [int]$newtextbox.top + 220
-                    $newtextbox.left = [int]$newtextbox.left - 10
-                }
-
-                $newtextbox.TextFrame.TextRange.Paragraphs(1).Text = $TicketName
-                $newtextbox.TextFrame.TextRange.Paragraphs(2).Text = "Status: $TicketStatus"
-                $newtextbox.TextFrame.TextRange.Paragraphs(3).Text = "Creation Date: $TicketDate"
-
-                if ($Loop -eq 3) {
-                    $Loop = 1
-                    $Slide ++
-                }
-                else {
                     $Loop ++
                 }
-                Start-Sleep -Milliseconds 500
-            }
-            }
-            else {
-            if ($Loop -eq 1) {
-                Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 29 - Adding new Slide..')
-
-                $Presentation.slides[$CurrentSlide].Duplicate() | Out-Null
-
-                $CurrentSlide ++
-
-                $NextSlide = $Presentation.Slides | Where-Object { $_.SlideIndex -eq $CurrentSlide }
-
-                ($NextSlide.Shapes | Where-Object { $_.name -eq 'Shape2' }).Delete()
-                ($NextSlide.Shapes | Where-Object { $_.name -eq 'Shape3' }).Delete()
-
-                ($NextSlide.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(1).Text = $TicketName
-                ($NextSlide.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(2).Text = "Status: $TicketStatus"
-                ($NextSlide.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(3).Text = "Creation Date: $TicketDate"
-
-                $Loop ++
-            }
-            else {
-                $newtextbox = ($NextSlide.Shapes | Where-Object { $_.Id -eq 7 }).Duplicate()
-
-                if ($Loop -eq 2) {
-                    $newtextbox.name = 'Shape2'
-                    $newtextbox.top = [int]$newtextbox.top + 100
-                    $newtextbox.left = [int]$newtextbox.left - 10
-                }
-                elseif ($Loop -eq 3) {
-                    $newtextbox.name = 'Shape3'
-                    $newtextbox.top = [int]$newtextbox.top + 220
-                    $newtextbox.left = [int]$newtextbox.left - 10
-                }
-
-                $newtextbox.TextFrame.TextRange.Paragraphs(1).Text = $TicketName
-                $newtextbox.TextFrame.TextRange.Paragraphs(2).Text = "Status: $TicketStatus"
-                $newtextbox.TextFrame.TextRange.Paragraphs(3).Text = "Creation Date: $TicketDate"
-
-                if ($Loop -eq 3) {
-                    $Loop = 1
-                    $Slide ++
-                }
                 else {
+                    $newtextbox = ($SlideSupportRequests.Shapes | Where-Object { $_.Id -eq 7 }).Duplicate()
+
+                    if ($Loop -eq 2) {
+                        $newtextbox.name = 'Shape2'
+                        $newtextbox.top = [int]$newtextbox.top + 100
+                        $newtextbox.left = [int]$newtextbox.left - 10
+                    }
+                    elseif ($Loop -eq 3) {
+                        $newtextbox.name = 'Shape3'
+                        $newtextbox.top = [int]$newtextbox.top + 220
+                        $newtextbox.left = [int]$newtextbox.left - 10
+                    }
+
+                    $newtextbox.TextFrame.TextRange.Paragraphs(1).Text = $TicketName
+                    $newtextbox.TextFrame.TextRange.Paragraphs(2).Text = "Status: $TicketStatus"
+                    $newtextbox.TextFrame.TextRange.Paragraphs(3).Text = "Creation Date: $TicketDate"
+
+                    if ($Loop -eq 3) {
+                        $Loop = 1
+                        $Slide ++
+                    }
+                    else {
+                        $Loop ++
+                    }
+                    Start-Sleep -Milliseconds 500
+                }
+            }
+            else {
+                if ($Loop -eq 1) {
+                    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 29 - Adding new Slide..')
+
+                    $Presentation.slides[$CurrentSlide].Duplicate() | Out-Null
+
+                    $CurrentSlide ++
+
+                    $NextSlide = $Presentation.Slides | Where-Object { $_.SlideIndex -eq $CurrentSlide }
+
+                    ($NextSlide.Shapes | Where-Object { $_.name -eq 'Shape2' }).Delete()
+                    ($NextSlide.Shapes | Where-Object { $_.name -eq 'Shape3' }).Delete()
+
+                    ($NextSlide.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(1).Text = $TicketName
+                    ($NextSlide.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(2).Text = "Status: $TicketStatus"
+                    ($NextSlide.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(3).Text = "Creation Date: $TicketDate"
+
                     $Loop ++
                 }
-            }
+                else {
+                    $newtextbox = ($NextSlide.Shapes | Where-Object { $_.Id -eq 7 }).Duplicate()
+
+                    if ($Loop -eq 2) {
+                        $newtextbox.name = 'Shape2'
+                        $newtextbox.top = [int]$newtextbox.top + 100
+                        $newtextbox.left = [int]$newtextbox.left - 10
+                    }
+                    elseif ($Loop -eq 3) {
+                        $newtextbox.name = 'Shape3'
+                        $newtextbox.top = [int]$newtextbox.top + 220
+                        $newtextbox.left = [int]$newtextbox.left - 10
+                    }
+
+                    $newtextbox.TextFrame.TextRange.Paragraphs(1).Text = $TicketName
+                    $newtextbox.TextFrame.TextRange.Paragraphs(2).Text = "Status: $TicketStatus"
+                    $newtextbox.TextFrame.TextRange.Paragraphs(3).Text = "Creation Date: $TicketDate"
+
+                    if ($Loop -eq 3) {
+                        $Loop = 1
+                        $Slide ++
+                    }
+                    else {
+                        $Loop ++
+                    }
+                }
             }
             Start-Sleep -Milliseconds 500
         }
     }
-    else
-    {
+    else {
         Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 29 - No Support Tickets found..')
         ($Presentation.Slides | Where-Object { $_.SlideIndex -eq 29 }).Delete()
     }
-  }
+}
 
-  ############# Slide 30
-  function Build-PPTSlide30 {
-    Param($Presentation,$AUTOMESSAGE,$Retirements)
+############# Slide 30
+function Build-PPTSlide30 {
+    Param($Presentation, $AUTOMESSAGE, $Retirements)
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 30 - Service Retirement Notifications..')
 
     $Loop = 1
@@ -915,110 +896,105 @@ $TableStyle = 'Light19'
     $CurrentSlide = 30
 
     if (![string]::IsNullOrEmpty($Retirements)) {
-    Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 30 - Service Retirement found..')
-    $SlideRetirements = $Presentation.Slides | Where-Object { $_.SlideIndex -eq $CurrentSlide }
+        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 30 - Service Retirement found..')
+        $SlideRetirements = $Presentation.Slides | Where-Object { $_.SlideIndex -eq $CurrentSlide }
 
-    $TargetShape = ($SlideRetirements.Shapes | Where-Object { $_.Id -eq 4 })
-    $TargetShape.TextFrame.TextRange.Text = $AUTOMESSAGE
+        $TargetShape = ($SlideRetirements.Shapes | Where-Object { $_.Id -eq 4 })
+        $TargetShape.TextFrame.TextRange.Text = $AUTOMESSAGE
 
-    ($SlideRetirements.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(1).Text = '.'
+        ($SlideRetirements.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(1).Text = '.'
 
-    foreach ($Retirement in $Retirements) {
+        foreach ($Retirement in $Retirements) {
+            $RetireName = ($Retirement.'Retirement TrackingId' + ' - ' + $Retirement.'Recommendation Title')
+            Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 30 - Adding Retirement: ' + $RetireName)
+            if ($Loop -lt 11) {
+                if ($Loop -eq 1) {
+                    ($SlideRetirements.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(1).Text = $RetireName
+                    $Loop ++
+                }
+                else {
+                    $NewShape = ($SlideRetirements.Shapes | Where-Object { $_.Id -eq 7 }).Duplicate()
 
-        $RetireName = ($Retirement.'Retirement TrackingId' + ' - ' + $Retirement.'Recommendation Title')
-        Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 30 - Adding Retirement: ' + $RetireName)
-        if ($Loop -lt 11) {
-            if ($Loop -eq 1) {
+                    $NewShape.name = ('Shape_' + $Loop)
+
+                    $NewShape.top = [int]$NewShape.top + ($Spacer * 40)
+                    $NewShape.left = [int]$NewShape.left - 10
+
+                    $NewShape.TextFrame.TextRange.Paragraphs(1).Text = $RetireName
+
+                    $Loop ++
+                    $Spacer ++
+                }
+            }
+            else {
+                Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 30 - Creating new Slide..')
+                $Loop = 1
+                $Spacer = 1
+
+                $Presentation.slides[$CurrentSlide].Duplicate() | Out-Null
+
+                $CurrentSlide ++
+
+                $SlideRetirements = $Presentation.Slides | Where-Object { $_.SlideIndex -eq $CurrentSlide }
+
+                $ShapesToDelete = $SlideRetirements.Shapes | Where-Object { $_.Name -like 'Shape_*' }
+
+                foreach ($Shape in $ShapesToDelete) {
+                    $Shape.Delete()
+                }
 
                 ($SlideRetirements.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(1).Text = $RetireName
                 $Loop ++
             }
-            else {
-
-                $NewShape = ($SlideRetirements.Shapes | Where-Object { $_.Id -eq 7 }).Duplicate()
-
-                $NewShape.name = ('Shape_'+$Loop)
-
-                $NewShape.top = [int]$NewShape.top + ($Spacer * 40)
-                $NewShape.left = [int]$NewShape.left - 10
-
-                $NewShape.TextFrame.TextRange.Paragraphs(1).Text = $RetireName
-
-                $Loop ++
-                $Spacer ++
-            }
-        }
-        else {
-            Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Editing Slide 30 - Creating new Slide..')
-            $Loop = 1
-            $Spacer = 1
-
-            $Presentation.slides[$CurrentSlide].Duplicate() | Out-Null
-
-            $CurrentSlide ++
-
-            $SlideRetirements = $Presentation.Slides | Where-Object { $_.SlideIndex -eq $CurrentSlide }
-
-            $ShapesToDelete = $SlideRetirements.Shapes | Where-Object { $_.Name -like 'Shape_*'}
-
-            Foreach ($Shape in $ShapesToDelete)
-                {
-                    $Shape.Delete()
-                }
-
-            ($SlideRetirements.Shapes | Where-Object { $_.Id -eq 7 }).TextFrame.TextRange.Paragraphs(1).Text = $RetireName
-            $Loop ++
-            }
         }
     }
-  }
+}
 
-  ######################## Assessment Findings Functions ##########################
+######################## Assessment Findings Functions ##########################
 
-  function Initialize-ExcelImpactedResources {
+function Initialize-ExcelImpactedResources {
     Param($ImpactedResources)
 
     $ImpactedResourcesFormatted = @()
 
     ForEach ($Resource in $ImpactedResources) {
-      $obj = @{
-        'Impacted?' = 'Yes';
-        'Resource Type' = $Resource.'Resource Type';
-        'subscriptionId' = $Resource.subscriptionId;
-        'resourceGroup' = $Resource.resourceGroup;
-        'location' = $Resource.location;
-        'name' = $Resource.name;
-        'id' = $Resource.id;
-        'custom1' = $Resource.custom1;
-        'custom2' = $Resource.custom2;
-        'custom3' = $Resource.custom3;
-        'custom4' = $Resource.custom4;
-        'custom5' = $Resource.custom5;
-        'Recommendation Title' = $Resource.'Recommendation Title';
-        'Impact' = $Resource.Impact;
-        'Recommendation Control' = $Resource.'Recommendation Control';
-        'Potential Benefit' = $Resource.'Potential Benefit';
-        'Learn More Link' = $Resource.'Learn More Link';
-        'Long Description' = $Resource.'Long Description';
-        'Guid' = $Resource.Guid;
-        'Category' = $Resource.Category;
-        'Source' = $Resource.'Source';
-        'WAF Pillar' = $Resource.'WAF Pillar';
-        'Platform Issue TrackingId' = $Resource.'Platform Issue TrackingId';
-        'Retirement TrackingId' = $Resource.'Retirement TrackingId';
-        'Support Request Number' = $Resource.'Support Request Number';
-        'Notes' = $Resource.Notes;
-        'checkName' = $Resource.checkName
-      }
-      $ImpactedResourcesFormatted += $obj
+        $obj = @{
+            'Impacted?'                 = 'Yes';
+            'Resource Type'             = $Resource.'Resource Type';
+            'subscriptionId'            = $Resource.subscriptionId;
+            'resourceGroup'             = $Resource.resourceGroup;
+            'location'                  = $Resource.location;
+            'name'                      = $Resource.name;
+            'id'                        = $Resource.id;
+            'custom1'                   = $Resource.custom1;
+            'custom2'                   = $Resource.custom2;
+            'custom3'                   = $Resource.custom3;
+            'custom4'                   = $Resource.custom4;
+            'custom5'                   = $Resource.custom5;
+            'Recommendation Title'      = $Resource.'Recommendation Title';
+            'Impact'                    = $Resource.Impact;
+            'Recommendation Control'    = $Resource.'Recommendation Control';
+            'Potential Benefit'         = $Resource.'Potential Benefit';
+            'Learn More Link'           = $Resource.'Learn More Link';
+            'Long Description'          = $Resource.'Long Description';
+            'Guid'                      = $Resource.Guid;
+            'Category'                  = $Resource.Category;
+            'Source'                    = $Resource.'Source';
+            'WAF Pillar'                = $Resource.'WAF Pillar';
+            'Platform Issue TrackingId' = $Resource.'Platform Issue TrackingId';
+            'Retirement TrackingId'     = $Resource.'Retirement TrackingId';
+            'Support Request Number'    = $Resource.'Support Request Number';
+            'Notes'                     = $Resource.Notes;
+            'checkName'                 = $Resource.checkName
+        }
+        $ImpactedResourcesFormatted += $obj
     }
 
     # Returns the array with all the recommendations already formatted to be exported to Excel
     return $ImpactedResourcesFormatted
+}
 
-  }
-
-  function Export-ExcelImpactedResources {
+function Export-ExcelImpactedResources {
     Param($ImpactedResourcesFormatted)
 
     $Style = @()
@@ -1064,65 +1040,62 @@ $TableStyle = 'Light19'
 
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Exporting Impacted Resources to Excel')
     $ImpactedResourcesFormatted | ForEach-Object { [PSCustomObject]$_ } | Select-Object $ImpactedResourcesSheet |
-      Export-Excel -Path $NewAssessmentFindingsFile -WorksheetName '3.ImpactedResources' -TableName 'impactedresources' -TableStyle $TableStyle -Style $Style -StartRow 12
+    Export-Excel -Path $NewAssessmentFindingsFile -WorksheetName '3.ImpactedResources' -TableName 'impactedresources' -TableStyle $TableStyle -Style $Style -StartRow 12
+}
 
-  }
-
-  function Initialize-ExcelRecommendations {
+function Initialize-ExcelRecommendations {
     Param($ImpactedResources)
 
     $RecommendationsFormatted = @()
 
-    $GroupedResources = $ImpactedResources.where({![String]::IsNullOrEmpty($_.Guid)}) | Group-Object -Property 'Guid' | Sort-Object -Property 'Count' -Descending
+    $GroupedResources = $ImpactedResources.where({ ![String]::IsNullOrEmpty($_.Guid) }) | Group-Object -Property 'Guid' | Sort-Object -Property 'Count' -Descending
 
-    $CustomRecommendations = $ImpactedResources.where({[String]::IsNullOrEmpty($_.Guid)})
+    $CustomRecommendations = $ImpactedResources.where({ [String]::IsNullOrEmpty($_.Guid) })
 
     ForEach ($Resource in $GroupedResources) {
 
-      $Recommendation = $ImpactedResources | Where-Object { $_.Guid -eq $Resource.Name } | Select-Object -First 1
+        $Recommendation = $ImpactedResources | Where-Object { $_.Guid -eq $Resource.Name } | Select-Object -First 1
 
-      $obj = @{
-        'Impact' = $Recommendation.Impact;
-        'Description' = $Recommendation.'Recommendation Title';
-        'Potential Benefit' = $Recommendation.'Potential Benefit';
-        'Impacted Resources' = $Resource.Count;
-        'Resource Type' = $Recommendation.'Resource Type';
-        'Recommendation Control' = $Recommendation.'Recommendation Control';
-        'Long Description' = $Recommendation.'Long Description';
-        'Category' = $Recommendation.Category;
-        'Learn More Link' = $Recommendation.'Learn More Link';
-        'Guid' = $Recommendation.Guid;
-        'Notes' = $Recommendation.Notes;
-      }
-      $RecommendationsFormatted += $obj
+        $obj = @{
+            'Impact'                 = $Recommendation.Impact;
+            'Description'            = $Recommendation.'Recommendation Title';
+            'Potential Benefit'      = $Recommendation.'Potential Benefit';
+            'Impacted Resources'     = $Resource.Count;
+            'Resource Type'          = $Recommendation.'Resource Type';
+            'Recommendation Control' = $Recommendation.'Recommendation Control';
+            'Long Description'       = $Recommendation.'Long Description';
+            'Category'               = $Recommendation.Category;
+            'Learn More Link'        = $Recommendation.'Learn More Link';
+            'Guid'                   = $Recommendation.Guid;
+            'Notes'                  = $Recommendation.Notes;
+        }
+        $RecommendationsFormatted += $obj
     }
 
     $CustomRecommendations.Foreach(
         {
             $obj = @{
-                'Impact' = $_.Impact;
-                'Description' = $_.'Recommendation Title'
-                'Potential Benefit' = $_.'Potential Benefit';
-                'Impacted Resources' = 1;
-                'Resource Type' = $_.'Resource Type';
+                'Impact'                 = $_.Impact;
+                'Description'            = $_.'Recommendation Title'
+                'Potential Benefit'      = $_.'Potential Benefit';
+                'Impacted Resources'     = 1;
+                'Resource Type'          = $_.'Resource Type';
                 'Recommendation Control' = $_.'Recommendation Control';
-                'Long Description' = $_.'Long Description';
-                'Category' = $_.Category;
-                'Learn More Link' = $_.'Learn More Link';
-                'Guid' = $_.Guid;
-                'Notes' = $_.Notes;
+                'Long Description'       = $_.'Long Description';
+                'Category'               = $_.Category;
+                'Learn More Link'        = $_.'Learn More Link';
+                'Guid'                   = $_.Guid;
+                'Notes'                  = $_.Notes;
             }
             $RecommendationsFormatted += $obj
         }
     )
 
-
     # Returns the array with all the recommendations already formatted to be exported to Excel
     return $RecommendationsFormatted
+}
 
-  }
-
-  function Export-ExcelRecommendations {
+function Export-ExcelRecommendations {
     Param($RecommendationsFormatted)
 
     $Style = @()
@@ -1156,11 +1129,10 @@ $TableStyle = 'Light19'
 
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Exporting Recommendations to Excel')
     $RecommendationsFormatted | ForEach-Object { [PSCustomObject]$_ } | Select-Object $RecommendationSheet |
-      Export-Excel -Path $NewAssessmentFindingsFile -WorksheetName '2.Recommendations' -TableName 'recommendationT' -TableStyle $TableStyle -Style $Style -StartRow 11
+    Export-Excel -Path $NewAssessmentFindingsFile -WorksheetName '2.Recommendations' -TableName 'recommendationT' -TableStyle $TableStyle -Style $Style -StartRow 11
+}
 
-  }
-
-  function Export-ExcelWorkloadInventory {
+function Export-ExcelWorkloadInventory {
     Param($ExcelWorkloadInventory)
 
     $Style = @()
@@ -1182,11 +1154,10 @@ $TableStyle = 'Light19'
 
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Exporting Workload Inventory to Excel')
     $ExcelWorkloadInventory | ForEach-Object { [PSCustomObject]$_ } | Select-Object $WorkloadSheet |
-      Export-Excel -Path $NewAssessmentFindingsFile -WorksheetName '6.WorkloadInventory' -TableName 'WorkloadResources' -TableStyle $TableStyle -Style $Style -StartRow 12
+    Export-Excel -Path $NewAssessmentFindingsFile -WorksheetName '6.WorkloadInventory' -TableName 'WorkloadResources' -TableStyle $TableStyle -Style $Style -StartRow 12
+}
 
-  }
-
-  function Build-ExcelPivotTable {
+function Build-ExcelPivotTable {
     Param($NewAssessmentFindingsFile)
 
     # Open the Excel file to add the Pivot Tables and Charts
@@ -1255,7 +1226,6 @@ $TableStyle = 'Light19'
     Add-PivotTable @PTParams
 
     return $Excel
-
 }
 
 function Build-ExcelPivotChart {
@@ -1264,8 +1234,8 @@ function Build-ExcelPivotChart {
     $ChartP0 = $Excel."1.Dashboard".Drawings.AddChart('ChartP0', 'BarClustered', $Excel."7.PivotTable".PivotTables['P0'])
     $ChartP0.SetSize(600, 700)
     $ChartP0.SetPosition(18, 10, .5, 90)
-    $ChartP0.fill.color = [System.Drawing.Color]::FromArgb(255,194,194,194)
-    $ChartP0.PlotArea.fill.color = [System.Drawing.Color]::FromArgb(255,194,194,194)
+    $ChartP0.fill.color = [System.Drawing.Color]::FromArgb(255, 194, 194, 194)
+    $ChartP0.PlotArea.fill.color = [System.Drawing.Color]::FromArgb(255, 194, 194, 194)
     $ChartP0.RoundedCorners = $true
     $ChartP0.Legend.Position = 'Top'
     #$ChartP0.DisplayBlanksAs = 'Gap'
@@ -1288,8 +1258,8 @@ function Build-ExcelPivotChart {
     $ChartP1 = $Excel."1.Dashboard".Drawings.AddChart('ChartP1', 'BarClustered', $Excel."7.PivotTable".PivotTables['P1'])
     $ChartP1.SetSize(500, 700)
     $ChartP1.SetPosition(18, 10, 6, 75)
-    $ChartP1.fill.color = [System.Drawing.Color]::FromArgb(255,194,194,194)
-    $ChartP1.PlotArea.fill.color = [System.Drawing.Color]::FromArgb(255,194,194,194)
+    $ChartP1.fill.color = [System.Drawing.Color]::FromArgb(255, 194, 194, 194)
+    $ChartP1.PlotArea.fill.color = [System.Drawing.Color]::FromArgb(255, 194, 194, 194)
     $ChartP1.RoundedCorners = $true
     $ChartP1.Legend.Position = 'Top'
     #$ChartP1.DisplayBlanksAs = 'Gap'
@@ -1308,7 +1278,6 @@ function Build-ExcelPivotChart {
     $ChartP1.YAxis.MinorTickMark = "None"
 
     Close-ExcelPackage $Excel
-
 }
 
 # Start the stopwatch to time the script
@@ -1398,31 +1367,26 @@ Build-ExcelPivotChart -Excel $ExcelFileLive
 try {
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting PowerPoint..')
     # Openning PPT
-    try
-    {
+    try {
         $Application = New-Object -ComObject PowerPoint.Application
         $Presentation = $Application.Presentations.Open($pptTemplateFilePath, $null, $null, $null)
     }
-    catch
-    {
+    catch {
         Write-Host ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + "- Error: " + $_.Exception.Message)
         Get-Process -Name "POWERPNT" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
     }
 
     Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Starting Excel..')
     # Openning Excel
-    try
-    {
+    try {
         $ExcelApplication = New-Object -ComObject Excel.Application
         Start-Sleep -Milliseconds 500
         $ExcelWorkbooks = $ExcelApplication.Workbooks.Open($NewAssessmentFindingsFile)
     }
-    catch
-    {
+    catch {
         Write-Host ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + "- Error: " + $_.Exception.Message)
         Get-Process -Name "excel" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
     }
-
 
     Remove-PPTSlide1 -Presentation $Presentation -CustomerName $CustomerName -WorkloadName $WorkloadName
     Build-PPTSlide12 -Presentation $Presentation -AUTOMESSAGE $AUTOMESSAGE -WorkloadName $WorkloadName -ResourcesType $ResourcesTypes
@@ -1463,14 +1427,12 @@ try {
     #}
 }
 finally {
-    if (Get-Process -Name "POWERPNT" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' })
-    {
+    if (Get-Process -Name "POWERPNT" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' }) {
         Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Trying to kill PowerPoint process.')
         Get-Process -Name "POWERPNT" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
     }
 
-    if (Get-Process -Name "excel" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } )
-    {
+    if (Get-Process -Name "excel" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } ) {
         Write-Debug ((get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Trying to kill Excel process.')
         Get-Process -Name "excel" -ErrorAction Ignore | Where-Object { $_.CommandLine -like '*/automation*' } | Stop-Process -Force
     }
@@ -1493,8 +1455,8 @@ Write-Host 'Assessment Findings File Saved as: ' -NoNewline
 Write-Host $NewAssessmentFindingsFile -ForegroundColor Cyan
 
 #if ($csvExport.IsPresent) {
-    Write-Host 'CSV File Saved as: ' -NoNewline
-    Write-Host $CSVFile -ForegroundColor Cyan
+Write-Host 'CSV File Saved as: ' -NoNewline
+Write-Host $CSVFile -ForegroundColor Cyan
 #}
 
 Write-Host "---------------------------------------------------------------------"


### PR DESCRIPTION
# Overview/Summary

- Formatted the code of the Start-WARAReport using the [PowerShell extension (PSScriptAnalyzer)](https://code.visualstudio.com/docs/languages/powershell) provided code formatting (`Format Document` command).

- No code changes.

- [PSScriptAnalyzer integration](https://code.visualstudio.com/docs/languages/powershell#_psscriptanalyzer-integration)
    > **PSScriptAnalyzer** also provides code formatting. You can invoke automatic document formatting with the **Format Document** command or the (`Shift+Alt+F`) keyboard shortcut.

    ![image](https://github.com/user-attachments/assets/c8da92cc-6dbc-4b4a-a26a-954cfb1a3c48)

## Related Issues/Work Items

None

### Breaking Changes

None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/Well-Architected-Reliability-Assessment/blob/main/docs/wara/contribution-guide.md) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Well-Architected-Reliability-Assessment/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Well-Architected-Reliability-Assessment/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Well-Architected-Reliability-Assessment/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
