### PR TITLE
fix: Bump CodeQL Action version to v3

### DIFF
--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -44,6 +44,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
# Overview/Summary

Updates CodeQL Action to v3 because v2 have been deprecated.

- [Code scanning: CodeQL Action v2 is now retired - GitHub Changelog](https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/)

![image](https://github.com/user-attachments/assets/997309f3-9a1f-41df-8b4c-e3ca33aa8875)

## Related Issues/Work Items

None

### Breaking Changes

None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/Well-Architected-Reliability-Assessment/blob/main/docs/wara/contribution-guide.md) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Well-Architected-Reliability-Assessment/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Well-Architected-Reliability-Assessment/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Well-Architected-Reliability-Assessment/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
